### PR TITLE
Fix post creation publishing flag

### DIFF
--- a/src/BlogApp.Application/Features/Posts/Commands/Create/CreatePostCommandHandler.cs
+++ b/src/BlogApp.Application/Features/Posts/Commands/Create/CreatePostCommandHandler.cs
@@ -18,7 +18,7 @@ public sealed class CreatePostCommandHandler(IPostRepository postRepository) : I
                 Body = request.Body,
                 Summary = request.Summary,
                 Thumbnail = request.Thumbnail,
-                IsPublished = false
+                IsPublished = request.IsPublished
             };
             await postRepository.AddAsync(post);
 


### PR DESCRIPTION
## Summary
- ensure the post creation handler persists the requested published status instead of forcing drafts

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f0933821c08320b8773dabcd9fd098