### PR TITLE
Restore Serilog global logger assignment

### DIFF
--- a/src/BlogApp.Persistence/DatabaseInitializer/DbInitializer.cs
+++ b/src/BlogApp.Persistence/DatabaseInitializer/DbInitializer.cs
@@ -43,7 +43,7 @@ public sealed class DbInitializer : IDbInitializer
             { "machine_name", new SinglePropertyColumnWriter("MachineName", PropertyWriteMethod.ToString, NpgsqlDbType.Text, "log") }
         };
 
-        using var logger = new LoggerConfiguration()
+        Log.Logger = new LoggerConfiguration()
             .WriteTo
             .PostgreSQL(
                 connectionString: postgreSqlConnectionString,
@@ -54,7 +54,7 @@ public sealed class DbInitializer : IDbInitializer
                 useCopy: false)
             .CreateLogger();
 
-        logger.Information("Serilog PostgreSQL tablosu doğrulandı.");
+        Log.Logger.Information("Serilog PostgreSQL tablosu doğrulandı.");
         return Task.CompletedTask;
     }
 }


### PR DESCRIPTION
## Summary
- restore the Serilog configuration to the global `Log.Logger`
- ensure initializer logging uses the configured global logger instance

## Testing
- not run (dotnet CLI unavailable in environment)

------
https://chatgpt.com/codex/tasks/task_e_68f0a5bea37483209990777d98048726