### PR TITLE
Fix pagination default index to avoid skipping first page

### DIFF
--- a/src/BlogApp.Domain/Common/Requests/PaginatedRequest.cs
+++ b/src/BlogApp.Domain/Common/Requests/PaginatedRequest.cs
@@ -2,7 +2,7 @@
 
 public class PaginatedRequest
 {
-    public const int DefaultPageIndex = 1;
+    public const int DefaultPageIndex = 0;
     public const int DefaultPageSize = 20;
     public const int MaxPageSize = 100;
 


### PR DESCRIPTION
## Summary
- restore `PaginatedRequest` default page index to zero so the first result page remains accessible with existing repository helpers

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f0cf3b38948320bc7951c86365f610