### PR TITLE
Replace Radzen templates causing compile errors

### DIFF
--- a/src/BlogApp.Client/Pages/Admin/Dashboard.razor
+++ b/src/BlogApp.Client/Pages/Admin/Dashboard.razor
@@ -43,8 +43,9 @@
                 <h3>Son Yorumlar</h3>
                 <span class="card-subtitle">Topluluk tarafından yapılan en yeni yorumlar</span>
             </div>
-            <RadzenListView Data="@recentComments" Style="max-height: 320px; overflow-y: auto;">
-                <Template Context="comment">
+            <div style="max-height: 320px; overflow-y: auto;">
+                @foreach (var comment in recentComments)
+                {
                     <div class="comment-item">
                         <RadzenAvatar Text="@comment.AuthorInitials" Style="margin-right: 0.75rem;" />
                         <div>
@@ -53,8 +54,8 @@
                             <p>@comment.Content</p>
                         </div>
                     </div>
-                </Template>
-            </RadzenListView>
+                }
+            </div>
         </RadzenCard>
     </RadzenColumn>
 </RadzenRow>

--- a/src/BlogApp.Client/Pages/Public/Home.razor
+++ b/src/BlogApp.Client/Pages/Public/Home.razor
@@ -7,11 +7,10 @@
         <p>Topluluğumuzdan en yeni güncellemeleri ve içerikleri keşfedin.</p>
     </RadzenColumn>
     <RadzenColumn Size="12" SizeMd="4" Class="filter-panel">
-        <RadzenTextBox Placeholder="Arama" Style="width: 100%;" @bind-Value="searchTerm">
-            <Suffix>
-                <RadzenButton Icon="search" ButtonStyle="ButtonStyle.Light" />
-            </Suffix>
-        </RadzenTextBox>
+        <RadzenStack Orientation="Orientation.Horizontal" Gap="8px" AlignItems="AlignItems.Stretch">
+            <RadzenTextBox Placeholder="Arama" Style="flex: 1 1 auto;" @bind-Value="searchTerm" />
+            <RadzenButton Icon="search" ButtonStyle="ButtonStyle.Light" />
+        </RadzenStack>
         <RadzenDropDown Data="@categories" TextProperty="Name" ValueProperty="Id" @bind-Value="selectedCategory" Style="width: 100%; margin-top: 0.75rem;" Placeholder="Kategori seçin" />
     </RadzenColumn>
 </RadzenRow>


### PR DESCRIPTION
## Summary
- replace the RadzenListView template with a standard foreach loop so the comment context compiles
- rework the home page search input to avoid unsupported Suffix markup and keep the Radzen button alongside the text box

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68f12fb7a0d083209a4fb409162cf93f