### PR TITLE
Fix Radzen component resolution and nullability warnings

### DIFF
--- a/src/BlogApp.Application/Features/AppRoles/Queries/GetRoleById/GetRoleByIdQueryHandler.cs
+++ b/src/BlogApp.Application/Features/AppRoles/Queries/GetRoleById/GetRoleByIdQueryHandler.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+using System.Threading.Tasks;
 using BlogApp.Application.Abstractions.Identity;
 using BlogApp.Domain.Common.Results;
 using BlogApp.Domain.Entities;
@@ -7,14 +9,17 @@ namespace BlogApp.Application.Features.AppRoles.Queries.GetRoleById;
 
 public class GetRoleByIdQueryHandler(IRoleService roleService) : IRequestHandler<GetRoleByIdRequest, IDataResult<GetRoleByIdQueryResponse>>
 {
-    public async Task<IDataResult<GetRoleByIdQueryResponse>> Handle(GetRoleByIdRequest request, CancellationToken cancellationToken)
+    public Task<IDataResult<GetRoleByIdQueryResponse>> Handle(GetRoleByIdRequest request, CancellationToken cancellationToken)
     {
         AppRole? role = roleService.GetRoleById(request.Id);
         if (role is null)
-            return new ErrorDataResult<GetRoleByIdQueryResponse>("Kullanýcý bulunamadý!");
+        {
+            IDataResult<GetRoleByIdQueryResponse> errorResult = new ErrorDataResult<GetRoleByIdQueryResponse>("KullanÄ±cÄ± bulunamadÄ±!");
+            return Task.FromResult(errorResult);
+        }
 
         GetRoleByIdQueryResponse result = new(Id: role.Id, Name: role.Name!);
-
-        return new SuccessDataResult<GetRoleByIdQueryResponse>(result);
+        IDataResult<GetRoleByIdQueryResponse> successResult = new SuccessDataResult<GetRoleByIdQueryResponse>(result);
+        return Task.FromResult(successResult);
     }
 }

--- a/src/BlogApp.Application/Features/AppUsers/Queries/GetById/GetByIdUserQueryHandler.cs
+++ b/src/BlogApp.Application/Features/AppUsers/Queries/GetById/GetByIdUserQueryHandler.cs
@@ -1,4 +1,6 @@
-﻿using AutoMapper;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
 using BlogApp.Application.Abstractions.Identity;
 using BlogApp.Domain.Common.Results;
 using BlogApp.Domain.Entities;
@@ -10,13 +12,17 @@ public sealed class GetByIdUserQueryHandler(
     IUserService userManager,
     IMapper mapper) : IRequestHandler<GetByIdAppUserQuery, IDataResult<GetByIdAppUserResponse>>
 {
-    public async Task<IDataResult<GetByIdAppUserResponse>> Handle(GetByIdAppUserQuery request, CancellationToken cancellationToken)
+    public Task<IDataResult<GetByIdAppUserResponse>> Handle(GetByIdAppUserQuery request, CancellationToken cancellationToken)
     {
         AppUser? user = userManager.FindById(request.Id);
         if (user is null)
-            return new ErrorDataResult<GetByIdAppUserResponse>("Kullanıcı bulunamadı!");
+        {
+            IDataResult<GetByIdAppUserResponse> errorResult = new ErrorDataResult<GetByIdAppUserResponse>("Kullanıcı bulunamadı!");
+            return Task.FromResult(errorResult);
+        }
 
-        var userResponse = mapper.Map<GetByIdAppUserResponse>(user);
-        return new SuccessDataResult<GetByIdAppUserResponse>(userResponse);
+        GetByIdAppUserResponse userResponse = mapper.Map<GetByIdAppUserResponse>(user);
+        IDataResult<GetByIdAppUserResponse> successResult = new SuccessDataResult<GetByIdAppUserResponse>(userResponse);
+        return Task.FromResult(successResult);
     }
 }

--- a/src/BlogApp.Application/Features/Categories/Queries/GetAll/GetAllCategoriesQueryHandler.cs
+++ b/src/BlogApp.Application/Features/Categories/Queries/GetAll/GetAllCategoriesQueryHandler.cs
@@ -1,4 +1,6 @@
-﻿using AutoMapper;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using BlogApp.Domain.Repositories;
 using MediatR;
 
@@ -7,16 +9,17 @@ namespace BlogApp.Application.Features.Categories.Queries.GetAll;
 public sealed class GetAllCategoriesQueryHandler(ICategoryRepository categoryRepository)
     : IRequestHandler<GetAllListCategoriesQuery, IQueryable>
 {
-    public async Task<IQueryable> Handle(GetAllListCategoriesQuery request, CancellationToken cancellationToken)
+    public Task<IQueryable> Handle(GetAllListCategoriesQuery request, CancellationToken cancellationToken)
     {
-        return categoryRepository
+        IQueryable query = categoryRepository
             .Query()
             .Where(x => x.IsDeleted == false)
-            .Select(x =>
-            new
+            .Select(x => new
             {
                 x.Id,
                 x.Name
             });
+
+        return Task.FromResult(query);
     }
 }

--- a/src/BlogApp.Client/Pages/Admin/Dashboard.razor
+++ b/src/BlogApp.Client/Pages/Admin/Dashboard.razor
@@ -1,4 +1,7 @@
 @page "/admin/dashboard"
+@using Radzen
+@using Radzen.Blazor
+
 <PageTitle>Admin Dashboard</PageTitle>
 
 <RadzenRow Class="page-header">

--- a/src/BlogApp.Client/Pages/Public/Home.razor
+++ b/src/BlogApp.Client/Pages/Public/Home.razor
@@ -1,4 +1,7 @@
 @page "/"
+@using Radzen
+@using Radzen.Blazor
+
 <PageTitle>Blog Ana Sayfası</PageTitle>
 
 <RadzenRow Class="page-header">

--- a/src/BlogApp.Domain/Common/Responses/PaginatedListResponse.cs
+++ b/src/BlogApp.Domain/Common/Responses/PaginatedListResponse.cs
@@ -5,11 +5,11 @@ namespace BlogApp.Domain.Common.Responses;
 
 public class PaginatedListResponse<T> : BasePageableModel
 {
-    private IList<T> _items;
+    private IList<T> _items = new List<T>();
 
     public IList<T> Items
     {
-        get => _items ??= new List<T>();
-        set => _items = value;
+        get => _items;
+        set => _items = value ?? new List<T>();
     }
 }

--- a/src/BlogApp.Domain/Common/Results/ApiResult.cs
+++ b/src/BlogApp.Domain/Common/Results/ApiResult.cs
@@ -5,10 +5,10 @@ namespace BlogApp.Domain.Common.Results
     public class ApiResult<T>
     {
         public bool Success { get; set; }
-        public string Message { get; set; }
-        public string InternalMessage { get; set; }
-        public T Data { get; set; }
-        public List<string> Errors { get; set; }
+        public string Message { get; set; } = string.Empty;
+        public string InternalMessage { get; set; } = string.Empty;
+        public T? Data { get; set; }
+        public List<string> Errors { get; set; } = new();
     }
 
     public class ApiReturn : ApiResult<object>

--- a/src/BlogApp.Domain/Common/Results/DataResult.cs
+++ b/src/BlogApp.Domain/Common/Results/DataResult.cs
@@ -2,18 +2,18 @@
 {
     public class DataResult<T> : Result, IDataResult<T>
     {
-        public DataResult(T data, bool success, string message)
+        public DataResult(T? data, bool success, string message)
             : base(success, message)
         {
             Data = data;
         }
 
-        public DataResult(T data, bool success)
+        public DataResult(T? data, bool success)
             : base(success)
         {
             Data = data;
         }
 
-        public T Data { get; }
+        public T? Data { get; }
     }
 }

--- a/src/BlogApp.Domain/Common/Results/Result.cs
+++ b/src/BlogApp.Domain/Common/Results/Result.cs
@@ -14,6 +14,6 @@
         }
 
         public bool Success { get; }
-        public string Message { get; }
+        public string Message { get; } = string.Empty;
     }
 }


### PR DESCRIPTION
## Summary
- add explicit Radzen namespace imports for dashboard and home pages to resolve component markup warnings
- initialize nullable-friendly defaults for common response and result models to silence non-nullable field/property warnings
- return Task.FromResult in synchronous query handlers to remove unnecessary async warnings

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68f1f1aca1cc8320805785badc180111