### PR TITLE
Add Docker Compose configurations for local development and production

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,35 @@ BlogApp; ASP.NET Core tabanlı arka uç ve Blazor Server tabanlı yönetim/son k
 - `/admin/dashboard` — Yönetim paneli, metrik kartları, trafik grafikleri ve gönderi listesi sunar.
 
 İstemciyi çalıştırmak için ilgili klasörde `dotnet run` komutunu kullanabilirsiniz.
+
+## Docker ile Çalıştırma
+
+Projeyi Docker Compose ile hem lokal geliştirme ortamında hem de Ubuntu tabanlı üretim sunucusunda çalıştırmak için ortak `docker-compose.yml` dosyasını, ortamınıza uygun ek dosya ile birlikte kullanabilirsiniz.
+
+### Lokal Geliştirme
+1. İmajları oluşturup konteynerleri ayağa kaldırmak için:
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.local.yml up --build
+   ```
+2. API `http://localhost:5000` üzerinden ulaşılabilir. PostgreSQL, RabbitMQ ve Redis portları da host makinenize yönlendirilir.
+3. Konteynerleri durdurmak için `Ctrl+C` kombinasyonunu kullanabilir veya aşağıdaki komutu çalıştırabilirsiniz:
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.local.yml down
+   ```
+
+### Ubuntu Üretim Sunucusu (Docker + Nginx)
+1. Gerekli imajları oluşturup konteynerleri arka planda başlatmak için:
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
+   ```
+2. API konteyneri yalnızca dahili Docker ağı üzerinden 8080 portunu dinler. Nginx reverse proxy konteyneri 80 numaralı portu dış dünyaya açarak trafiği API servisine yönlendirir.
+3. Servisleri durdurmak için aşağıdaki komutu kullanabilirsiniz:
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.prod.yml down
+   ```
+
+### Ortam Değişkenleri
+- `ASPNETCORE_ENVIRONMENT`: Varsayılan olarak üretimde `Production`, lokal ortamda `Development` olarak ayarlanır.
+- `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`: PostgreSQL veritabanı ayarlarını özelleştirmek için kullanılabilir.
+
+Kalıcı veriler Docker volume'ları (`postgres_data`, `rabbitmq_data`, `redis_data`) üzerinde saklanır.

--- a/deploy/nginx/default.conf
+++ b/deploy/nginx/default.conf
@@ -1,0 +1,12 @@
+server {
+    listen 80;
+    server_name _;
+
+    location / {
+        proxy_pass http://blogapp.api:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,24 @@
+version: "3.8"
+
+services:
+  blogapp.api:
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_URLS: http://0.0.0.0:8080
+    ports:
+      - "5000:8080"
+    volumes:
+      - ./src/BlogApp.API/appsettings.Development.json:/app/appsettings.Development.json:ro
+
+  postgresdb:
+    ports:
+      - "5435:5432"
+
+  rabbitmq:
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+
+  redis.cache:
+    ports:
+      - "6379:6379"

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,15 +1,12 @@
-
-version: '3.4'
+version: "3.8"
 
 services:
   blogapp.api:
     environment:
       ASPNETCORE_ENVIRONMENT: Development
-      ASPNETCORE_HTTP_PORTS: 5000
-      ASPNETCORE_HTTPS_PORTS: 5001
+      ASPNETCORE_URLS: http://0.0.0.0:8080
     ports:
-      - "5000:5000"
-      - "5001:5001"
+      - "5000:8080"
     volumes:
       - ${APPDATA}/Microsoft/UserSecrets:/home/app/.microsoft/usersecrets:ro
       - ${APPDATA}/ASP.NET/Https:/home/app/.aspnet/https:ro

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,22 @@
+version: "3.8"
+
+services:
+  blogapp.api:
+    environment:
+      ASPNETCORE_ENVIRONMENT: Production
+      ASPNETCORE_URLS: http://0.0.0.0:8080
+
+  postgresdb:
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-BlogAppDb}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+
+  nginx:
+    image: nginx:1.25
+    depends_on:
+      - blogapp.api
+    volumes:
+      - ./deploy/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+    ports:
+      - "80:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,8 @@
+version: "3.8"
 
-version: '3.4'
+x-app-environment: &app-environment
+  ASPNETCORE_ENVIRONMENT: ${ASPNETCORE_ENVIRONMENT:-Production}
+  ASPNETCORE_URLS: ${ASPNETCORE_URLS:-http://0.0.0.0:8080}
 
 services:
   blogapp.api:
@@ -8,11 +11,9 @@ services:
       context: .
       dockerfile: src/BlogApp.API/Dockerfile
     environment:
-      ASPNETCORE_ENVIRONMENT: Development
-      ASPNETCORE_URLS: http://0.0.0.0:5000;https://0.0.0.0:5001
-    ports:
-      - "5000:5000"
-      - "5001:5001"
+      <<: *app-environment
+    expose:
+      - "8080"
     depends_on:
       - postgresdb
       - rabbitmq
@@ -22,28 +23,28 @@ services:
     container_name: postgresdb
     image: postgres:14
     environment:
-      POSTGRES_DB: BlogAppDb
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: ${POSTGRES_DB:-BlogAppDb}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
     volumes:
-      - ./postgresdb:/var/lib/postgresql/data
-    ports:
-      - "5435:5432"
+      - postgres_data:/var/lib/postgresql/data
 
   rabbitmq:
     image: rabbitmq:3-management
     container_name: rabbitmq
     hostname: rabbitmq
-    ports:
-      - "5672:5672"
-      - "15672:15672"
     volumes:
-      - ./rabbitmq:/var/lib/rabbitmq/mnesia/
+      - rabbitmq_data:/var/lib/rabbitmq/mnesia/
     restart: always
 
   redis.cache:
     image: redis:latest
     container_name: redis_server
     restart: always
-    ports:
-      - "6379:6379"
+    volumes:
+      - redis_data:/data
+
+volumes:
+  postgres_data:
+  rabbitmq_data:
+  redis_data:


### PR DESCRIPTION
## Summary
- update the base docker-compose.yml to share configuration between environments
- add dedicated compose files for local development and production with nginx reverse proxy
- document docker-based workflows and supply an nginx config for the production stack

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f87f3b9f9c832084d7771f475c656e