### PR TITLE
Update production Nginx to listen on host 8080

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Projeyi Docker Compose ile hem lokal geliştirme ortamında hem de Ubuntu tabanl
    ```bash
    docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
    ```
-2. API konteyneri yalnızca dahili Docker ağı üzerinden 8080 portunu dinler. Nginx reverse proxy konteyneri 80 numaralı portu dış dünyaya açarak trafiği API servisine yönlendirir.
+2. API konteyneri yalnızca dahili Docker ağı üzerinden 8080 portunu dinler. Nginx reverse proxy konteyneri host üzerindeki 8080 numaralı portu dış dünyaya açarak gelen trafiği container içindeki 80 numaralı porta ve oradan API servisine yönlendirir.
 3. Servisleri durdurmak için aşağıdaki komutu kullanabilirsiniz:
    ```bash
    docker compose -f docker-compose.yml -f docker-compose.prod.yml down

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -19,4 +19,4 @@ services:
     volumes:
       - ./deploy/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
     ports:
-      - "80:80"
+      - "8080:80"


### PR DESCRIPTION
## Summary
- map the production Nginx container to host port 8080 to avoid conflicts with existing services
- document the new port mapping in the deployment section of the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f8b21c1a108320a6d15b5e6afdd468