### PR TITLE
Configure RabbitMQ credentials for Docker deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,9 @@ services:
     image: rabbitmq:3-management
     container_name: rabbitmq
     hostname: rabbitmq
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_DEFAULT_USER:-blogapp}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_DEFAULT_PASS:-supersecret}
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq/mnesia/
     restart: always

--- a/src/BlogApp.API/appsettings.Production.json
+++ b/src/BlogApp.API/appsettings.Production.json
@@ -22,8 +22,8 @@
 
   "RabbitMQOptions": {
     "HostName": "rabbitmq",
-    "UserName": "guest",
-    "Password": "guest",
+    "UserName": "blogapp",
+    "Password": "supersecret",
     "RetryLimit": 10
   },
 


### PR DESCRIPTION
## Summary
- configure the RabbitMQ service in docker-compose to provision a dedicated user that works across containers
- update the production API settings to use the same RabbitMQ credentials

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f8cf1934148320a8d6546a96c5afee