### PR TITLE
Configure RabbitMQ credentials for Docker deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,14 @@ Projeyi Docker Compose ile hem lokal geliştirme ortamında hem de Ubuntu tabanl
 - `ASPNETCORE_ENVIRONMENT`: Varsayılan olarak üretimde `Production`, lokal ortamda `Development` olarak ayarlanır.
 - `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`: PostgreSQL veritabanı ayarlarını özelleştirmek için kullanılabilir.
 
-Kalıcı veriler Docker volume'ları (`postgres_data`, `rabbitmq_data`, `redis_data`) üzerinde saklanır.
+Kalıcı veriler Docker volume'ları (`postgres_data`, `rabbitmq_data`, `redis_data`) üzerinde saklanır. RabbitMQ için kullanıcı
+adını/şifresini değiştirirseniz mevcut `rabbitmq_data` volume'unda eski kimlik bilgileri tutulmaya devam ettiği için konteyner yeni
+değerlerle açıldığında oturum açma sorunları yaşayabilirsiniz. Bu durumda servisleri durdurduktan sonra volume'u silerek yeniden
+oluşturmalısınız:
+
+```bash
+docker compose down
+docker volume rm blogapp_rabbitmq_data
+```
+
+Ardından konteynerleri tekrar ayağa kaldırdığınızda (`docker compose up --build`) volume otomatik olarak yeniden oluşturulur.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,9 @@ services:
       dockerfile: src/BlogApp.API/Dockerfile
     environment:
       <<: *app-environment
+      RabbitMQOptions__HostName: rabbitmq
+      RabbitMQOptions__UserName: ${RABBITMQ_DEFAULT_USER:-blogapp}
+      RabbitMQOptions__Password: ${RABBITMQ_DEFAULT_PASS:-supersecret}
     expose:
       - "8080"
     depends_on:
@@ -33,6 +36,9 @@ services:
     image: rabbitmq:3-management
     container_name: rabbitmq
     hostname: rabbitmq
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_DEFAULT_USER:-blogapp}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_DEFAULT_PASS:-supersecret}
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq/mnesia/
     restart: always

--- a/src/BlogApp.API/appsettings.Production.json
+++ b/src/BlogApp.API/appsettings.Production.json
@@ -22,8 +22,8 @@
 
   "RabbitMQOptions": {
     "HostName": "rabbitmq",
-    "UserName": "guest",
-    "Password": "guest",
+    "UserName": "blogapp",
+    "Password": "supersecret",
     "RetryLimit": 10
   },
 


### PR DESCRIPTION
## Summary
- configure the RabbitMQ service in docker-compose to provision a dedicated user that works across containers
- update the production API settings to use the same RabbitMQ credentials
- expose the RabbitMQ connection settings to the API container via environment variables so MassTransit no longer falls back to the guest account

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f8cf1934148320a8d6546a96c5afee