### PR TITLE
Handle missing Redis configuration by using in-memory cache fallback

### DIFF
--- a/src/BlogApp.Infrastructure/InfrastructureServicesRegistration.cs
+++ b/src/BlogApp.Infrastructure/InfrastructureServicesRegistration.cs
@@ -76,8 +76,16 @@ namespace BlogApp.Infrastructure
                 };
             });
 
-            services.AddStackExchangeRedisCache(options =>
-                options.Configuration = configuration.GetConnectionString("RedisCache"));
+            var redisConnectionString = configuration.GetConnectionString("RedisCache");
+            if (!string.IsNullOrWhiteSpace(redisConnectionString))
+            {
+                services.AddStackExchangeRedisCache(options =>
+                    options.Configuration = redisConnectionString);
+            }
+            else
+            {
+                services.AddDistributedMemoryCache();
+            }
 
             services.AddMassTransit(x =>
             {


### PR DESCRIPTION
## Summary
- add a fallback to the in-memory distributed cache when the Redis connection string is not provided

## Testing
- not run (runtime not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f90d990b38832092320bd5aed3b5ac