### PR TITLE
Add PostgreSQL healthcheck for API startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     healthcheck:
       test:
         - "CMD-SHELL"
-        - "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-BlogAppDb}"
+        - "PGPASSWORD=${POSTGRES_PASSWORD:-postgres} pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-BlogAppDb} -h localhost"
       interval: 10s
       timeout: 5s
       retries: 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       rabbitmq:
         condition: service_healthy
       postgresdb:
-        condition: service_started
+        condition: service_healthy
       redis.cache:
         condition: service_started
 
@@ -34,6 +34,14 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-BlogAppDb}"
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
 
   rabbitmq:
     image: rabbitmq:3-management


### PR DESCRIPTION
## Summary
- add a healthcheck to the postgres service so readiness is detected before other services start
- require the API service to wait for the postgres health status before starting

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f91448c28c8320b2466ba359d30a61