### PR TITLE
Add React client application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -286,6 +286,11 @@ FakesAssemblies/
 .ntvs_analysis.dat
 node_modules/
 
+# Frontend client artifacts
+clients/blogapp-client/node_modules/
+clients/blogapp-client/dist/
+clients/blogapp-client/.env
+
 # Visual Studio 6 build log
 *.plg
 

--- a/clients/blogapp-client/.env.example
+++ b/clients/blogapp-client/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:5000/api

--- a/clients/blogapp-client/.gitignore
+++ b/clients/blogapp-client/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.DS_Store
+dist
+.env
+*.local

--- a/clients/blogapp-client/README.md
+++ b/clients/blogapp-client/README.md
@@ -1,0 +1,26 @@
+# BlogApp React Client
+
+Modern, production-grade React istemcisi BlogApp API ile entegre olacak şekilde hazırlanmıştır.
+
+## Başlangıç
+
+1. Bağımlılıkları yükleyin:
+   ```bash
+   npm install
+   ```
+2. Ortam değişkenlerini ayarlayın:
+   - `.env.example` dosyasını kopyalayarak `.env` oluşturun ve gerekli API adresini güncelleyin.
+3. Geliştirme sunucusunu başlatın:
+   ```bash
+   npm run dev
+   ```
+
+## Özellikler
+
+- Vite + React + TypeScript
+- TailwindCSS, shadcn/ui ve lucide-react ile modern arayüz
+- React Router v7 ile yönlendirme
+- TanStack Query ve Axios ile veri yönetimi
+- Zustand tabanlı oturum yönetimi, JWT desteği ve interceptor
+- React Hook Form + Zod ile form doğrulama
+- Kategori yönetimi için sunucu taraflı sıralama/filtreleme/sayfalama

--- a/clients/blogapp-client/index.html
+++ b/clients/blogapp-client/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="tr">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>BlogApp</title>
+  </head>
+  <body class="bg-background text-foreground">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/clients/blogapp-client/package.json
+++ b/clients/blogapp-client/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "blogapp-client",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@hookform/resolvers": "^3.4.1",
+    "@radix-ui/react-dialog": "^1.1.1",
+    "@radix-ui/react-label": "^2.1.0",
+    "@radix-ui/react-slot": "^1.1.0",
+    "@tanstack/react-query": "^5.51.21",
+    "@tanstack/react-table": "^8.21.2",
+    "axios": "^1.7.7",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.0",
+    "framer-motion": "^11.5.4",
+    "lucide-react": "^0.460.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-hook-form": "^7.53.0",
+    "react-hot-toast": "^2.4.1",
+    "react-router-dom": "^7.0.2",
+    "zustand": "^4.5.4",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^22.7.4",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0",
+    "@vitejs/plugin-react": "^4.3.2",
+    "autoprefixer": "^10.4.20",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-refresh": "^0.4.7",
+    "postcss": "^8.4.45",
+    "prettier": "^3.3.3",
+    "tailwindcss": "^3.4.13",
+    "tailwindcss-animate": "^1.0.7",
+    "typescript": "^5.5.4",
+    "vite": "^5.4.1"
+  }
+}

--- a/clients/blogapp-client/postcss.config.js
+++ b/clients/blogapp-client/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/clients/blogapp-client/src/components/admin/admin-header.tsx
+++ b/clients/blogapp-client/src/components/admin/admin-header.tsx
@@ -1,0 +1,43 @@
+import { Menu, SunMoon } from 'lucide-react';
+import { motion } from 'framer-motion';
+import { Button } from '../ui/button';
+import { useAuth } from '../../hooks/use-auth';
+
+interface AdminHeaderProps {
+  onToggleSidebar: () => void;
+  isCollapsed: boolean;
+}
+
+export function AdminHeader({ onToggleSidebar, isCollapsed }: AdminHeaderProps) {
+  const { user, logout } = useAuth();
+
+  return (
+    <motion.header
+      className="flex h-16 items-center justify-between border-b bg-background px-4"
+      initial={{ y: -20, opacity: 0 }}
+      animate={{ y: 0, opacity: 1 }}
+    >
+      <div className="flex items-center gap-3">
+        <Button variant="ghost" size="icon" onClick={onToggleSidebar}>
+          <Menu className="h-5 w-5" />
+          <span className="sr-only">Menüyü Aç/Kapat</span>
+        </Button>
+        <span className="text-sm text-muted-foreground">
+          {isCollapsed ? 'Panel' : 'Yönetim Paneli'}
+        </span>
+      </div>
+      <div className="flex items-center gap-3">
+        <Button variant="ghost" size="icon">
+          <SunMoon className="h-5 w-5" />
+          <span className="sr-only">Tema Değiştir</span>
+        </Button>
+        <div className="flex flex-col items-end text-sm">
+          <span className="font-medium">{user?.userName}</span>
+          <button className="text-xs text-muted-foreground hover:text-primary" onClick={logout}>
+            Çıkış Yap
+          </button>
+        </div>
+      </div>
+    </motion.header>
+  );
+}

--- a/clients/blogapp-client/src/components/admin/sidebar.tsx
+++ b/clients/blogapp-client/src/components/admin/sidebar.tsx
@@ -1,0 +1,48 @@
+import { NavLink } from 'react-router-dom';
+import { FolderKanban, LayoutDashboard } from 'lucide-react';
+import { cn } from '../../lib/utils';
+
+const links = [
+  {
+    to: '/admin/dashboard',
+    label: 'Dashboard',
+    icon: LayoutDashboard
+  },
+  {
+    to: '/admin/categories',
+    label: 'Kategoriler',
+    icon: FolderKanban
+  }
+];
+
+export function AdminSidebar({ collapsed }: { collapsed: boolean }) {
+  return (
+    <aside
+      className={cn(
+        'border-r bg-card transition-all duration-300',
+        collapsed ? 'w-16' : 'w-64'
+      )}
+    >
+      <div className="flex h-16 items-center justify-center border-b text-lg font-semibold">
+        {collapsed ? 'BA' : 'BlogApp'}
+      </div>
+      <nav className="space-y-1 p-4">
+        {links.map((link) => (
+          <NavLink
+            key={link.to}
+            to={link.to}
+            className={({ isActive }) =>
+              cn(
+                'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-muted',
+                isActive ? 'bg-muted text-primary' : 'text-muted-foreground'
+              )
+            }
+          >
+            <link.icon className="h-5 w-5" />
+            {!collapsed && <span>{link.label}</span>}
+          </NavLink>
+        ))}
+      </nav>
+    </aside>
+  );
+}

--- a/clients/blogapp-client/src/components/layout/admin-layout.tsx
+++ b/clients/blogapp-client/src/components/layout/admin-layout.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+import { Outlet } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import { AdminSidebar } from '../admin/sidebar';
+import { AdminHeader } from '../admin/admin-header';
+
+export function AdminLayout() {
+  const [collapsed, setCollapsed] = useState(false);
+
+  return (
+    <div className="flex min-h-screen bg-muted/30">
+      <AdminSidebar collapsed={collapsed} />
+      <div className="flex flex-1 flex-col">
+        <AdminHeader
+          isCollapsed={collapsed}
+          onToggleSidebar={() => setCollapsed((prev) => !prev)}
+        />
+        <motion.main
+          className="flex-1 p-6"
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.25 }}
+        >
+          <Outlet />
+        </motion.main>
+      </div>
+    </div>
+  );
+}

--- a/clients/blogapp-client/src/components/layout/footer.tsx
+++ b/clients/blogapp-client/src/components/layout/footer.tsx
@@ -1,0 +1,10 @@
+export function Footer() {
+  return (
+    <footer className="border-t bg-background">
+      <div className="container flex flex-col items-center justify-between gap-2 py-6 text-sm text-muted-foreground sm:flex-row">
+        <span>&copy; {new Date().getFullYear()} BlogApp. Tüm hakları saklıdır.</span>
+        <span>Modern içerik platformu</span>
+      </div>
+    </footer>
+  );
+}

--- a/clients/blogapp-client/src/components/layout/public-layout.tsx
+++ b/clients/blogapp-client/src/components/layout/public-layout.tsx
@@ -1,0 +1,23 @@
+import { Outlet } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import { Navbar } from '../navigation/navbar';
+import { Footer } from './footer';
+
+export function PublicLayout() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Navbar />
+      <main className="flex-1">
+        <motion.div
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.3 }}
+          className="container py-10"
+        >
+          <Outlet />
+        </motion.div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/clients/blogapp-client/src/components/navigation/navbar.tsx
+++ b/clients/blogapp-client/src/components/navigation/navbar.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+import { Link, NavLink } from 'react-router-dom';
+import { Menu, X } from 'lucide-react';
+import { Button } from '../ui/button';
+import { useAuth } from '../../hooks/use-auth';
+import { cn } from '../../lib/utils';
+
+const navLinkClass = ({ isActive }: { isActive: boolean }) =>
+  cn(
+    'px-3 py-2 text-sm font-medium transition-colors hover:text-primary',
+    isActive ? 'text-primary' : 'text-muted-foreground'
+  );
+
+export function Navbar() {
+  const [open, setOpen] = useState(false);
+  const { isAuthenticated, logout, user } = useAuth();
+
+  const handleLogout = () => {
+    logout();
+  };
+
+  return (
+    <header className="border-b bg-background/80 backdrop-blur">
+      <div className="container flex items-center justify-between py-4">
+        <Link to="/" className="text-xl font-semibold">
+          BlogApp
+        </Link>
+        <nav className="hidden items-center gap-4 md:flex">
+          <NavLink to="/" className={navLinkClass} end>
+            Anasayfa
+          </NavLink>
+          {isAuthenticated ? (
+            <>
+              <NavLink to="/admin/dashboard" className={navLinkClass}>
+                Admin
+              </NavLink>
+              <span className="text-sm text-muted-foreground">{user?.userName}</span>
+              <Button variant="ghost" size="sm" onClick={handleLogout}>
+                Çıkış
+              </Button>
+            </>
+          ) : (
+            <NavLink to="/login" className={navLinkClass}>
+              Giriş
+            </NavLink>
+          )}
+        </nav>
+        <button
+          className="md:hidden"
+          onClick={() => setOpen((prev) => !prev)}
+          aria-label="Menüyü Aç"
+        >
+          {open ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
+        </button>
+      </div>
+      {open && (
+        <div className="border-t bg-background md:hidden">
+          <nav className="container flex flex-col gap-2 py-4">
+            <NavLink to="/" className={navLinkClass} end onClick={() => setOpen(false)}>
+              Anasayfa
+            </NavLink>
+            {isAuthenticated ? (
+              <>
+                <NavLink
+                  to="/admin/dashboard"
+                  className={navLinkClass}
+                  onClick={() => setOpen(false)}
+                >
+                  Admin
+                </NavLink>
+                <div className="flex items-center justify-between px-3 text-sm text-muted-foreground">
+                  <span>{user?.userName}</span>
+                  <Button variant="ghost" size="sm" onClick={handleLogout}>
+                    Çıkış
+                  </Button>
+                </div>
+              </>
+            ) : (
+              <NavLink to="/login" className={navLinkClass} onClick={() => setOpen(false)}>
+                Giriş
+              </NavLink>
+            )}
+          </nav>
+        </div>
+      )}
+    </header>
+  );
+}

--- a/clients/blogapp-client/src/components/ui/badge.tsx
+++ b/clients/blogapp-client/src/components/ui/badge.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '../../lib/utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-primary text-primary-foreground shadow',
+        secondary: 'border-transparent bg-secondary text-secondary-foreground',
+        outline: 'text-foreground'
+      }
+    },
+    defaultVariants: {
+      variant: 'default'
+    }
+  }
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/clients/blogapp-client/src/components/ui/button.tsx
+++ b/clients/blogapp-client/src/components/ui/button.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '../../lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground shadow hover:bg-primary/90',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        destructive: 'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
+        link: 'text-primary underline-offset-4 hover:underline'
+      },
+      size: {
+        default: 'h-10 px-4 py-2',
+        sm: 'h-9 rounded-md px-3',
+        lg: 'h-11 rounded-md px-8',
+        icon: 'h-10 w-10'
+      }
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default'
+    }
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button';
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };

--- a/clients/blogapp-client/src/components/ui/card.tsx
+++ b/clients/blogapp-client/src/components/ui/card.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('rounded-lg border bg-card text-card-foreground shadow-sm', className)}
+      {...props}
+    />
+  )
+);
+Card.displayName = 'Card';
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
+  )
+);
+CardHeader.displayName = 'CardHeader';
+
+const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3
+      ref={ref}
+      className={cn('text-2xl font-semibold leading-none tracking-tight', className)}
+      {...props}
+    />
+  )
+);
+CardTitle.displayName = 'CardTitle';
+
+const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
+  )
+);
+CardDescription.displayName = 'CardDescription';
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+  )
+);
+CardContent.displayName = 'CardContent';
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex items-center p-6 pt-0', className)} {...props} />
+  )
+);
+CardFooter.displayName = 'CardFooter';
+
+export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter };

--- a/clients/blogapp-client/src/components/ui/dialog.tsx
+++ b/clients/blogapp-client/src/components/ui/dialog.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+import { cn } from '../../lib/utils';
+
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+const DialogPortal = DialogPrimitive.Portal;
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn('fixed inset-0 z-50 bg-black/50 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0', className)}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
+);
+DialogHeader.displayName = 'DialogHeader';
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)} {...props} />
+);
+DialogFooter.displayName = 'DialogFooter';
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+  DialogClose
+};

--- a/clients/blogapp-client/src/components/ui/input.tsx
+++ b/clients/blogapp-client/src/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type = 'text', ...props }, ref) => {
+  return (
+    <input
+      type={type}
+      className={cn(
+        'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Input.displayName = 'Input';
+
+export { Input };

--- a/clients/blogapp-client/src/components/ui/label.tsx
+++ b/clients/blogapp-client/src/components/ui/label.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import * as LabelPrimitive from '@radix-ui/react-label';
+import { cn } from '../../lib/utils';
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn('text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70', className)}
+    {...props}
+  />
+));
+Label.displayName = LabelPrimitive.Root.displayName;
+
+export { Label };

--- a/clients/blogapp-client/src/components/ui/separator.tsx
+++ b/clients/blogapp-client/src/components/ui/separator.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+const Separator = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & { orientation?: 'horizontal' | 'vertical' }
+>(({ className, orientation = 'horizontal', ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      'shrink-0 bg-border',
+      orientation === 'horizontal' ? 'h-px w-full' : 'h-full w-px',
+      className
+    )}
+    role="separator"
+    aria-orientation={orientation}
+    {...props}
+  />
+));
+Separator.displayName = 'Separator';
+
+export { Separator };

--- a/clients/blogapp-client/src/components/ui/table.tsx
+++ b/clients/blogapp-client/src/components/ui/table.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
+  ({ className, ...props }, ref) => (
+    <div className="w-full overflow-auto">
+      <table
+        ref={ref}
+        className={cn('w-full caption-bottom text-sm', className)}
+        {...props}
+      />
+    </div>
+  )
+);
+Table.displayName = 'Table';
+
+const TableHeader = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />
+  )
+);
+TableHeader.displayName = 'TableHeader';
+
+const TableBody = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <tbody ref={ref} className={cn('[&_tr:last-child]:border-0', className)} {...props} />
+  )
+);
+TableBody.displayName = 'TableBody';
+
+const TableFooter = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <tfoot
+      ref={ref}
+      className={cn('bg-muted/50 font-medium [&>tr]:last:border-b-0', className)}
+      {...props}
+    />
+  )
+);
+TableFooter.displayName = 'TableFooter';
+
+const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
+  ({ className, ...props }, ref) => (
+    <tr
+      ref={ref}
+      className={cn('border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted', className)}
+      {...props}
+    />
+  )
+);
+TableRow.displayName = 'TableRow';
+
+const TableHead = React.forwardRef<HTMLTableCellElement, React.ThHTMLAttributes<HTMLTableCellElement>>(
+  ({ className, ...props }, ref) => (
+    <th
+      ref={ref}
+      className={cn('h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0', className)}
+      {...props}
+    />
+  )
+);
+TableHead.displayName = 'TableHead';
+
+const TableCell = React.forwardRef<HTMLTableCellElement, React.TdHTMLAttributes<HTMLTableCellElement>>(
+  ({ className, ...props }, ref) => (
+    <td
+      ref={ref}
+      className={cn('p-4 align-middle [&:has([role=checkbox])]:pr-0', className)}
+      {...props}
+    />
+  )
+);
+TableCell.displayName = 'TableCell';
+
+const TableCaption = React.forwardRef<HTMLTableCaptionElement, React.HTMLAttributes<HTMLTableCaptionElement>>(
+  ({ className, ...props }, ref) => (
+    <caption
+      ref={ref}
+      className={cn('mt-4 text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  )
+);
+TableCaption.displayName = 'TableCaption';
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption
+};

--- a/clients/blogapp-client/src/features/auth/api.ts
+++ b/clients/blogapp-client/src/features/auth/api.ts
@@ -1,0 +1,8 @@
+import api from '../../lib/axios';
+import { ApiResult, normalizeApiResult } from '../../types/api';
+import { LoginRequest, LoginResponse } from './types';
+
+export async function login(request: LoginRequest): Promise<ApiResult<LoginResponse>> {
+  const response = await api.post<ApiResult<LoginResponse>>('/Auth/Login', request);
+  return normalizeApiResult<LoginResponse>(response.data);
+}

--- a/clients/blogapp-client/src/features/auth/types.ts
+++ b/clients/blogapp-client/src/features/auth/types.ts
@@ -1,0 +1,10 @@
+import { AuthUser } from '../../stores/auth-store';
+
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface LoginResponse extends AuthUser {
+  token: string;
+}

--- a/clients/blogapp-client/src/features/categories/api.ts
+++ b/clients/blogapp-client/src/features/categories/api.ts
@@ -1,0 +1,75 @@
+import api from '../../lib/axios';
+import { ApiResult, normalizeApiResult, normalizePaginatedResponse } from '../../types/api';
+import {
+  Category,
+  CategoryFormValues,
+  CategoryListResponse,
+  CategoryTableFilters
+} from './types';
+
+function buildDataGridPayload(filters: CategoryTableFilters) {
+  const payload: Record<string, unknown> = {
+    PaginatedRequest: {
+      PageIndex: filters.pageIndex,
+      PageSize: filters.pageSize
+    }
+  };
+
+  const sort = filters.sort
+    ? [
+        {
+          Field: filters.sort.field,
+          Dir: filters.sort.dir
+        }
+      ]
+    : undefined;
+
+  const filter = filters.search
+    ? {
+        Field: 'Name',
+        Operator: 'contains',
+        Value: filters.search
+      }
+    : undefined;
+
+  if (sort || filter) {
+    payload.DynamicQuery = {
+      ...(sort ? { Sort: sort } : {}),
+      ...(filter ? { Filter: filter } : {})
+    };
+  }
+
+  return payload;
+}
+
+export async function fetchCategories(
+  filters: CategoryTableFilters
+): Promise<CategoryListResponse> {
+  const response = await api.post('/Category/GetPaginatedList', buildDataGridPayload(filters));
+  return normalizePaginatedResponse<Category>(response.data);
+}
+
+export async function createCategory(values: CategoryFormValues) {
+  const response = await api.post<ApiResult>('/Category/Create', {
+    Name: values.name
+  });
+  return normalizeApiResult(response.data);
+}
+
+export async function updateCategory(id: number, values: CategoryFormValues) {
+  const response = await api.put<ApiResult>('/Category/Update', {
+    Id: id,
+    Name: values.name
+  });
+  return normalizeApiResult(response.data);
+}
+
+export async function deleteCategory(id: number) {
+  const response = await api.delete<ApiResult>(`/Category/Delete/${id}`);
+  return normalizeApiResult(response.data);
+}
+
+export async function getAllCategories(): Promise<Category[]> {
+  const response = await api.get<Category[]>('/Category/GetAll');
+  return response.data;
+}

--- a/clients/blogapp-client/src/features/categories/types.ts
+++ b/clients/blogapp-client/src/features/categories/types.ts
@@ -1,0 +1,22 @@
+import { PaginatedListResponse } from '../../types/api';
+
+export interface Category {
+  id: number;
+  name: string;
+}
+
+export type CategoryListResponse = PaginatedListResponse<Category>;
+
+export interface CategoryFormValues {
+  name: string;
+}
+
+export interface CategoryTableFilters {
+  search?: string;
+  pageIndex: number;
+  pageSize: number;
+  sort?: {
+    field: string;
+    dir: 'asc' | 'desc';
+  };
+}

--- a/clients/blogapp-client/src/features/posts/api.ts
+++ b/clients/blogapp-client/src/features/posts/api.ts
@@ -1,0 +1,28 @@
+import api from '../../lib/axios';
+import { normalizePaginatedResponse } from '../../types/api';
+import { PostListResponse, PostSummary } from './types';
+
+export async function fetchPublishedPosts(pageIndex = 0, pageSize = 6) {
+  const payload = {
+    PaginatedRequest: {
+      PageIndex: pageIndex,
+      PageSize: pageSize
+    },
+    DynamicQuery: {
+      Filter: {
+        Field: 'IsPublished',
+        Operator: 'eq',
+        Value: true
+      },
+      Sort: [
+        {
+          Field: 'Id',
+          Dir: 'desc'
+        }
+      ]
+    }
+  };
+
+  const response = await api.post<PostListResponse>('/Post/GetPaginatedList', payload);
+  return normalizePaginatedResponse<PostSummary>(response.data);
+}

--- a/clients/blogapp-client/src/features/posts/types.ts
+++ b/clients/blogapp-client/src/features/posts/types.ts
@@ -1,0 +1,13 @@
+import { PaginatedListResponse } from '../../types/api';
+
+export interface PostSummary {
+  id: number;
+  title: string;
+  summary: string;
+  thumbnail: string;
+  isPublished: boolean;
+  categoryName: string;
+  categoryId: number;
+}
+
+export type PostListResponse = PaginatedListResponse<PostSummary>;

--- a/clients/blogapp-client/src/hooks/use-auth.ts
+++ b/clients/blogapp-client/src/hooks/use-auth.ts
@@ -3,6 +3,7 @@ import { useAuthStore } from '../stores/auth-store';
 export function useAuth() {
   const user = useAuthStore((state) => state.user);
   const token = useAuthStore((state) => state.token);
+  const hydrated = useAuthStore((state) => state.hydrated);
   const login = useAuthStore((state) => state.login);
   const logout = useAuthStore((state) => state.logout);
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated());
@@ -10,6 +11,7 @@ export function useAuth() {
   return {
     user,
     token,
+    hydrated,
     login,
     logout,
     isAuthenticated

--- a/clients/blogapp-client/src/hooks/use-auth.ts
+++ b/clients/blogapp-client/src/hooks/use-auth.ts
@@ -1,0 +1,17 @@
+import { useAuthStore } from '../stores/auth-store';
+
+export function useAuth() {
+  const user = useAuthStore((state) => state.user);
+  const token = useAuthStore((state) => state.token);
+  const login = useAuthStore((state) => state.login);
+  const logout = useAuthStore((state) => state.logout);
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated());
+
+  return {
+    user,
+    token,
+    login,
+    logout,
+    isAuthenticated
+  };
+}

--- a/clients/blogapp-client/src/index.css
+++ b/clients/blogapp-client/src/index.css
@@ -1,0 +1,56 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: 0 0% 100%;
+  --foreground: 222.2 47.4% 11.2%;
+  --muted: 210 40% 96.1%;
+  --muted-foreground: 215.4 16.3% 46.9%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 222.2 47.4% 11.2%;
+  --card: 0 0% 100%;
+  --card-foreground: 222.2 47.4% 11.2%;
+  --border: 214.3 31.8% 91.4%;
+  --input: 214.3 31.8% 91.4%;
+  --primary: 221.2 83.2% 53.3%;
+  --primary-foreground: 210 40% 98%;
+  --secondary: 210 40% 96.1%;
+  --secondary-foreground: 222.2 47.4% 11.2%;
+  --accent: 210 40% 96.1%;
+  --accent-foreground: 222.2 47.4% 11.2%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 210 40% 98%;
+  --ring: 221.2 83.2% 53.3%;
+  --radius: 0.75rem;
+}
+
+.dark {
+  --background: 224 71% 4%;
+  --foreground: 213 31% 91%;
+  --muted: 223 47% 11%;
+  --muted-foreground: 215.4 16.3% 56.9%;
+  --popover: 224 71% 4%;
+  --popover-foreground: 215 20.2% 65.1%;
+  --card: 224 71% 4%;
+  --card-foreground: 213 31% 91%;
+  --border: 216 34% 17%;
+  --input: 216 34% 17%;
+  --primary: 210 40% 98%;
+  --primary-foreground: 222.2 47.4% 1.2%;
+  --secondary: 217.2 32.6% 17.5%;
+  --secondary-foreground: 210 40% 98%;
+  --accent: 217.2 32.6% 17.5%;
+  --accent-foreground: 210 40% 98%;
+  --destructive: 0 62.8% 30.6%;
+  --destructive-foreground: 210 40% 98%;
+  --ring: 216 34% 17%;
+}
+
+body {
+  @apply bg-background text-foreground antialiased;
+}
+
+html, body, #root {
+  height: 100%;
+}

--- a/clients/blogapp-client/src/lib/axios.ts
+++ b/clients/blogapp-client/src/lib/axios.ts
@@ -1,0 +1,35 @@
+import axios from 'axios';
+import { useAuthStore } from '../stores/auth-store';
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_URL,
+  withCredentials: true
+});
+
+api.interceptors.request.use((config) => {
+  const token = useAuthStore.getState().token;
+  if (token) {
+    config.headers = {
+      ...config.headers,
+      Authorization: `Bearer ${token}`
+    };
+  }
+  return config;
+});
+
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 401) {
+      const { logout } = useAuthStore.getState();
+      logout();
+      if (typeof window !== 'undefined') {
+        window.location.href = '/login';
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);
+
+export default api;

--- a/clients/blogapp-client/src/lib/utils.ts
+++ b/clients/blogapp-client/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/clients/blogapp-client/src/main.tsx
+++ b/clients/blogapp-client/src/main.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { RouterProvider } from 'react-router-dom';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { queryClient } from './providers/query-client';
+import { router } from './routes/router';
+import { Toaster } from 'react-hot-toast';
+import './index.css';
+
+const rootElement = document.getElementById('root');
+
+if (!rootElement) {
+  throw new Error('Root element not found');
+}
+
+ReactDOM.createRoot(rootElement).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+      <Toaster position="top-right" />
+    </QueryClientProvider>
+  </React.StrictMode>
+);

--- a/clients/blogapp-client/src/pages/admin/categories-page.tsx
+++ b/clients/blogapp-client/src/pages/admin/categories-page.tsx
@@ -1,0 +1,450 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  ColumnDef,
+  SortingState,
+  flexRender,
+  getCoreRowModel,
+  useReactTable
+} from '@tanstack/react-table';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
+import { PlusCircle, Pencil, Trash2, ArrowUpDown } from 'lucide-react';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { fetchCategories, createCategory, updateCategory, deleteCategory } from '../../features/categories/api';
+import {
+  Category,
+  CategoryFormValues,
+  CategoryTableFilters
+} from '../../features/categories/types';
+import { Button } from '../../components/ui/button';
+import { Input } from '../../components/ui/input';
+import { Label } from '../../components/ui/label';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../components/ui/table';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger
+} from '../../components/ui/dialog';
+import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card';
+import { Separator } from '../../components/ui/separator';
+import { cn } from '../../lib/utils';
+
+const categorySchema = z.object({
+  name: z.string().min(2, 'Kategori adı en az 2 karakter olmalıdır')
+});
+
+type CategoryFormSchema = z.infer<typeof categorySchema>;
+
+const fieldMap: Record<string, string> = {
+  id: 'Id',
+  name: 'Name'
+};
+
+export function CategoriesPage() {
+  const queryClient = useQueryClient();
+  const [filters, setFilters] = useState<CategoryTableFilters>({
+    pageIndex: 0,
+    pageSize: 10
+  });
+  const [searchTerm, setSearchTerm] = useState('');
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: 'name', desc: false }
+  ]);
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [editingCategory, setEditingCategory] = useState<Category | null>(null);
+  const [categoryToDelete, setCategoryToDelete] = useState<Category | null>(null);
+
+  const categoriesQuery = useQuery({
+    queryKey: [
+      'categories',
+      filters.pageIndex,
+      filters.pageSize,
+      filters.search ?? '',
+      filters.sort?.field ?? '',
+      filters.sort?.dir ?? ''
+    ],
+    queryFn: () => fetchCategories(filters),
+    keepPreviousData: true
+  });
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setFilters((prev) => ({ ...prev, search: searchTerm, pageIndex: 0 }));
+    }, 400);
+
+    return () => window.clearTimeout(timeout);
+  }, [searchTerm]);
+
+  useEffect(() => {
+    setFilters((prev) => {
+      const sortState = sorting[0];
+      const nextSort = sortState
+        ? {
+            field: fieldMap[sortState.id] ?? sortState.id,
+            dir: sortState.desc ? 'desc' : 'asc'
+          }
+        : undefined;
+
+      if (
+        (prev.sort?.field ?? '') === (nextSort?.field ?? '') &&
+        (prev.sort?.dir ?? '') === (nextSort?.dir ?? '')
+      ) {
+        return prev;
+      }
+
+      return {
+        ...prev,
+        sort: nextSort,
+        pageIndex: 0
+      };
+    });
+  }, [sorting]);
+
+  const columns = useMemo<ColumnDef<Category>[]>(
+    () => [
+      {
+        accessorKey: 'id',
+        header: 'ID',
+        cell: ({ row }) => <span className="font-mono text-xs text-muted-foreground">#{row.original.id}</span>,
+        enableSorting: true
+      },
+      {
+        accessorKey: 'name',
+        header: ({ column }) => (
+          <Button
+            variant="ghost"
+            className="-ml-3 h-8"
+            onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
+          >
+            Kategori Adı
+            <ArrowUpDown className="ml-2 h-4 w-4" />
+          </Button>
+        ),
+        cell: ({ row }) => <span className="font-medium">{row.original.name}</span>,
+        enableSorting: true
+      },
+      {
+        id: 'actions',
+        header: 'İşlemler',
+        cell: ({ row }) => (
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => setEditingCategory(row.original)}
+              aria-label="Düzenle"
+            >
+              <Pencil className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => setCategoryToDelete(row.original)}
+              aria-label="Sil"
+            >
+              <Trash2 className="h-4 w-4 text-destructive" />
+            </Button>
+          </div>
+        )
+      }
+    ],
+    []
+  );
+
+  const table = useReactTable({
+    data: categoriesQuery.data?.items ?? [],
+    columns,
+    state: {
+      sorting
+    },
+    onSortingChange: setSorting,
+    manualSorting: true,
+    getCoreRowModel: getCoreRowModel()
+  });
+
+  const createMutation = useMutation({
+    mutationFn: createCategory,
+    onSuccess: (result) => {
+      if (!result.success) {
+        toast.error(result.message || 'Kategori eklenemedi');
+        return;
+      }
+      toast.success(result.message || 'Kategori eklendi');
+      setIsCreateOpen(false);
+      queryClient.invalidateQueries({ queryKey: ['categories'] });
+    },
+    onError: () => toast.error('Kategori eklenirken bir hata oluştu')
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (values: CategoryFormValues) =>
+      editingCategory ? updateCategory(editingCategory.id, values) : Promise.reject(),
+    onSuccess: (result) => {
+      if (!result.success) {
+        toast.error(result.message || 'Kategori güncellenemedi');
+        return;
+      }
+      toast.success(result.message || 'Kategori güncellendi');
+      setEditingCategory(null);
+      queryClient.invalidateQueries({ queryKey: ['categories'] });
+    },
+    onError: () => toast.error('Kategori güncellenirken bir hata oluştu')
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (categoryId: number) => deleteCategory(categoryId),
+    onSuccess: (result) => {
+      if (!result.success) {
+        toast.error(result.message || 'Kategori silinemedi');
+        return;
+      }
+      toast.success(result.message || 'Kategori silindi');
+      setCategoryToDelete(null);
+      queryClient.invalidateQueries({ queryKey: ['categories'] });
+    },
+    onError: () => toast.error('Kategori silinirken bir hata oluştu')
+  });
+
+  const handlePageChange = (direction: 'prev' | 'next') => {
+    setFilters((prev) => {
+      const nextIndex = direction === 'prev' ? Math.max(prev.pageIndex - 1, 0) : prev.pageIndex + 1;
+      return {
+        ...prev,
+        pageIndex: nextIndex
+      };
+    });
+  };
+
+  const handlePageSizeChange = (value: number) => {
+    setFilters((prev) => ({
+      ...prev,
+      pageSize: value,
+      pageIndex: 0
+    }));
+  };
+
+  const formMethods = useForm<CategoryFormSchema>({
+    resolver: zodResolver(categorySchema),
+    defaultValues: {
+      name: ''
+    }
+  });
+
+  useEffect(() => {
+    if (editingCategory) {
+      formMethods.reset({ name: editingCategory.name });
+    } else {
+      formMethods.reset({ name: '' });
+    }
+  }, [editingCategory, formMethods]);
+
+  const onSubmit = formMethods.handleSubmit(async (values) => {
+    if (editingCategory) {
+      await updateMutation.mutateAsync(values);
+    } else {
+      await createMutation.mutateAsync(values);
+    }
+    formMethods.reset({ name: '' });
+  });
+
+  const totalPages = categoriesQuery.data?.pages ?? 0;
+  const currentPage = categoriesQuery.data?.index ?? filters.pageIndex;
+  const isFirstPage = currentPage <= 0;
+  const isLastPage = totalPages > 0 ? currentPage >= totalPages - 1 : false;
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <CardTitle>Kategori Yönetimi</CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Kategorilerinizi oluşturun, düzenleyin ve yönetin. Arama, sıralama ve sayfalama özelliklerini kullanın.
+            </p>
+          </div>
+          <Dialog
+            open={isCreateOpen}
+            onOpenChange={(open) => {
+              setIsCreateOpen(open);
+              if (!open && !editingCategory) {
+                formMethods.reset({ name: '' });
+              }
+            }}
+          >
+            <DialogTrigger asChild>
+              <Button className="gap-2">
+                <PlusCircle className="h-4 w-4" /> Yeni Kategori
+              </Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Yeni Kategori</DialogTitle>
+                <DialogDescription>Blogunuz için yeni bir kategori oluşturun.</DialogDescription>
+              </DialogHeader>
+              <form id="create-category-form" onSubmit={onSubmit} className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="category-name">Kategori Adı</Label>
+                  <Input id="category-name" placeholder="Teknoloji" {...formMethods.register('name')} />
+                  {formMethods.formState.errors.name && (
+                    <p className="text-sm text-destructive">{formMethods.formState.errors.name.message}</p>
+                  )}
+                </div>
+              </form>
+              <DialogFooter className="gap-2">
+                <Button type="button" variant="ghost" onClick={() => setIsCreateOpen(false)}>
+                  İptal
+                </Button>
+                <Button type="submit" form="create-category-form" disabled={createMutation.isPending}>
+                  {createMutation.isPending ? 'Kaydediliyor...' : 'Kaydet'}
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <Input
+              placeholder="Kategori ara..."
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              className="md:w-72"
+            />
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <span>Sayfa başına:</span>
+              <select
+                className="rounded-md border bg-background px-2 py-1"
+                value={filters.pageSize}
+                onChange={(event) => handlePageSizeChange(Number(event.target.value))}
+              >
+                {[5, 10, 20, 50].map((size) => (
+                  <option key={size} value={size}>
+                    {size}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+          <div className="overflow-hidden rounded-lg border bg-background">
+            <Table>
+              <TableHeader>
+                {table.getHeaderGroups().map((headerGroup) => (
+                  <TableRow key={headerGroup.id}>
+                    {headerGroup.headers.map((header) => (
+                      <TableHead key={header.id} className={cn(header.column.id === 'actions' && 'w-[120px]')}>
+                        {header.isPlaceholder
+                          ? null
+                          : flexRender(header.column.columnDef.header, header.getContext())}
+                      </TableHead>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableHeader>
+              <TableBody>
+                {categoriesQuery.isLoading ? (
+                  <TableRow>
+                    <TableCell colSpan={columns.length} className="h-24 text-center">
+                      Veriler yükleniyor...
+                    </TableCell>
+                  </TableRow>
+                ) : table.getRowModel().rows.length ? (
+                  table.getRowModel().rows.map((row) => (
+                    <TableRow key={row.id}>
+                      {row.getVisibleCells().map((cell) => (
+                        <TableCell key={cell.id}>
+                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  ))
+                ) : (
+                  <TableRow>
+                    <TableCell colSpan={columns.length} className="h-24 text-center">
+                      Kategori bulunamadı.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+          <div className="flex flex-col items-center justify-between gap-3 border-t pt-4 text-sm text-muted-foreground md:flex-row">
+            <div>
+              Toplam {categoriesQuery.data?.count ?? 0} kayıt - Sayfa {currentPage + 1} / {totalPages || 1}
+            </div>
+            <div className="flex items-center gap-2">
+              <Button variant="outline" size="sm" onClick={() => handlePageChange('prev')} disabled={isFirstPage}>
+                Önceki
+              </Button>
+              <Button variant="outline" size="sm" onClick={() => handlePageChange('next')} disabled={isLastPage}>
+                Sonraki
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Dialog open={!!editingCategory} onOpenChange={(open) => !open && setEditingCategory(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Kategoriyi Düzenle</DialogTitle>
+            <DialogDescription>Seçili kategorinin adını güncelleyin.</DialogDescription>
+          </DialogHeader>
+          <form id="edit-category-form" onSubmit={onSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="edit-category-name">Kategori Adı</Label>
+              <Input
+                id="edit-category-name"
+                placeholder="Kategori adı"
+                {...formMethods.register('name')}
+              />
+              {formMethods.formState.errors.name && (
+                <p className="text-sm text-destructive">{formMethods.formState.errors.name.message}</p>
+              )}
+            </div>
+          </form>
+          <DialogFooter className="gap-2">
+            <Button type="button" variant="ghost" onClick={() => setEditingCategory(null)}>
+              İptal
+            </Button>
+            <Button type="submit" form="edit-category-form" disabled={updateMutation.isPending}>
+              {updateMutation.isPending ? 'Güncelleniyor...' : 'Güncelle'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={!!categoryToDelete} onOpenChange={(open) => !open && setCategoryToDelete(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Kategoriyi Sil</DialogTitle>
+            <DialogDescription>
+              Bu kategoriyi silmek istediğinizden emin misiniz? İşlem geri alınamaz.
+            </DialogDescription>
+          </DialogHeader>
+          <Separator />
+          <p className="text-sm text-muted-foreground">
+            Silinecek kategori: <span className="font-medium">{categoryToDelete?.name}</span>
+          </p>
+          <DialogFooter className="gap-2">
+            <Button type="button" variant="ghost" onClick={() => setCategoryToDelete(null)}>
+              İptal
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={deleteMutation.isPending}
+              onClick={() => categoryToDelete && deleteMutation.mutate(categoryToDelete.id)}
+            >
+              {deleteMutation.isPending ? 'Siliniyor...' : 'Sil'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/clients/blogapp-client/src/pages/admin/dashboard-page.tsx
+++ b/clients/blogapp-client/src/pages/admin/dashboard-page.tsx
@@ -1,0 +1,82 @@
+import { motion } from 'framer-motion';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../components/ui/card';
+import { Separator } from '../../components/ui/separator';
+import { Button } from '../../components/ui/button';
+
+const highlights = [
+  {
+    title: 'Son 7 Gün',
+    description: 'Yeni yayınlanan gönderiler',
+    value: '12'
+  },
+  {
+    title: 'Aktif Kategoriler',
+    description: 'İçerikleriniz bu kategorilerde sınıflandırıldı',
+    value: '8'
+  },
+  {
+    title: 'Bekleyen Taslaklar',
+    description: 'Yayınlanmayı bekleyen içerikler',
+    value: '4'
+  }
+];
+
+export function DashboardPage() {
+  return (
+    <div className="space-y-8">
+      <motion.div
+        className="flex flex-col gap-4 rounded-xl border bg-card p-6 shadow-sm lg:flex-row lg:items-center lg:justify-between"
+        initial={{ opacity: 0, y: 16 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.25 }}
+      >
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Yönetim Paneline Hoş Geldiniz</h1>
+          <p className="mt-2 max-w-xl text-sm text-muted-foreground">
+            BlogApp içeriklerinizi kolayca yönetin, yeni kategoriler oluşturun ve gönderilerinizi düzenleyin. Sağ menüden ilgili alanlara hızlıca ulaşabilirsiniz.
+          </p>
+        </div>
+        <Button size="lg">Yeni Gönderi Oluştur</Button>
+      </motion.div>
+
+      <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+        {highlights.map((item, index) => (
+          <motion.div
+            key={item.title}
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: index * 0.1 }}
+          >
+            <Card className="h-full">
+              <CardHeader>
+                <CardTitle className="text-lg">{item.title}</CardTitle>
+                <CardDescription>{item.description}</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <p className="text-3xl font-semibold">{item.value}</p>
+              </CardContent>
+            </Card>
+          </motion.div>
+        ))}
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Son Aktiviteler</CardTitle>
+          <CardDescription>Ekibinizin son gerçekleştirdiği işlemleri görüntüleyin.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {[1, 2, 3].map((activity) => (
+            <div key={activity} className="space-y-2">
+              <div className="flex items-center justify-between text-sm">
+                <span className="font-medium">Yeni kategori oluşturuldu</span>
+                <span className="text-muted-foreground">2 saat önce</span>
+              </div>
+              <Separator />
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/clients/blogapp-client/src/pages/public/home-page.tsx
+++ b/clients/blogapp-client/src/pages/public/home-page.tsx
@@ -1,0 +1,115 @@
+import { useQuery } from '@tanstack/react-query';
+import { motion } from 'framer-motion';
+import { fetchPublishedPosts } from '../../features/posts/api';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../components/ui/card';
+import { Badge } from '../../components/ui/badge';
+import { Button } from '../../components/ui/button';
+
+export function HomePage() {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['posts', 'published'],
+    queryFn: () => fetchPublishedPosts(0, 9)
+  });
+
+  return (
+    <div className="space-y-10">
+      <section className="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
+        <div className="space-y-4">
+          <motion.h1
+            className="text-3xl font-bold tracking-tight sm:text-4xl"
+            initial={{ y: 10, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            transition={{ delay: 0.1 }}
+          >
+            En Yeni Hikayelerle İlham Alın
+          </motion.h1>
+          <motion.p
+            className="text-lg text-muted-foreground"
+            initial={{ y: 10, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            transition={{ delay: 0.2 }}
+          >
+            BlogApp, teknoloji, tasarım ve üretkenlik dünyasından en güncel içerikleri
+            sunar. Topluluğumuza katılın ve uzmanlardan öğrenin.
+          </motion.p>
+          <motion.div
+            initial={{ y: 10, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            transition={{ delay: 0.3 }}
+          >
+            <Button size="lg">Keşfetmeye Başla</Button>
+          </motion.div>
+        </div>
+        <motion.div
+          className="relative hidden rounded-3xl border bg-gradient-to-br from-primary/10 to-secondary/10 p-8 lg:flex lg:flex-col lg:justify-between"
+          initial={{ opacity: 0, scale: 0.98 }}
+          animate={{ opacity: 1, scale: 1 }}
+        >
+          <div>
+            <Badge variant="secondary">Trend Konu</Badge>
+            <h2 className="mt-4 text-2xl font-semibold">Yapay Zeka ile Üretkenlik</h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Modern iş akışlarında yapay zekanın rolü ve geleceğin yetenekleri üzerine derinlemesine analiz.
+            </p>
+          </div>
+          <div className="mt-6 text-sm text-muted-foreground">
+            Her hafta onlarca yeni makale yayımlanıyor. Haber bültenimize abone olun.
+          </div>
+        </motion.div>
+      </section>
+
+      <section className="space-y-6">
+        <div className="flex items-center justify-between">
+          <h2 className="text-2xl font-semibold">Öne Çıkan Yazılar</h2>
+          <Button variant="ghost" size="sm">
+            Tüm Yazılar
+          </Button>
+        </div>
+        {isError && (
+          <p className="text-sm text-destructive">Gönderiler yüklenirken bir hata oluştu.</p>
+        )}
+        <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
+          {isLoading &&
+            Array.from({ length: 6 }).map((_, index) => (
+              <div key={index} className="h-56 animate-pulse rounded-xl bg-muted" />
+            ))}
+          {!isLoading && data?.items.length === 0 && (
+            <p className="text-sm text-muted-foreground">Henüz yayınlanmış gönderi bulunmuyor.</p>
+          )}
+          {data?.items.map((post, index) => (
+            <motion.article
+              key={post.id}
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: index * 0.05 }}
+            >
+              <Card className="h-full overflow-hidden">
+                {post.thumbnail && (
+                  <div className="h-40 w-full overflow-hidden">
+                    <img
+                      src={post.thumbnail}
+                      alt={post.title}
+                      className="h-full w-full object-cover transition-transform duration-300 hover:scale-105"
+                    />
+                  </div>
+                )}
+                <CardHeader className="space-y-2">
+                  <Badge variant="outline">{post.categoryName}</Badge>
+                  <CardTitle className="line-clamp-2 text-xl">{post.title}</CardTitle>
+                  <CardDescription className="line-clamp-3 text-sm">
+                    {post.summary}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <Button variant="link" className="px-0">
+                    Devamını Oku
+                  </Button>
+                </CardContent>
+              </Card>
+            </motion.article>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/clients/blogapp-client/src/pages/public/login-page.tsx
+++ b/clients/blogapp-client/src/pages/public/login-page.tsx
@@ -1,0 +1,113 @@
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate, useLocation } from 'react-router-dom';
+import toast from 'react-hot-toast';
+import { motion } from 'framer-motion';
+import { login } from '../../features/auth/api';
+import { useAuthStore } from '../../stores/auth-store';
+import { Button } from '../../components/ui/button';
+import { Input } from '../../components/ui/input';
+import { Label } from '../../components/ui/label';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../components/ui/card';
+
+const loginSchema = z.object({
+  email: z.string().email('Geçerli bir e-posta adresi girin'),
+  password: z.string().min(6, 'Şifre en az 6 karakter olmalıdır')
+});
+
+type LoginFormValues = z.infer<typeof loginSchema>;
+
+export function LoginPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const loginStore = useAuthStore((state) => state.login);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors }
+  } = useForm<LoginFormValues>({
+    resolver: zodResolver(loginSchema),
+    defaultValues: {
+      email: '',
+      password: ''
+    }
+  });
+
+  const { mutateAsync, isPending } = useMutation({
+    mutationFn: login,
+    onSuccess: (response) => {
+      if (!response.success) {
+        toast.error(response.message || 'Giriş başarısız oldu');
+        return;
+      }
+
+      loginStore({
+        user: {
+          userId: response.data.userId,
+          userName: response.data.userName,
+          expiration: response.data.expiration,
+          refreshToken: response.data.refreshToken
+        },
+        token: response.data.token
+      });
+
+      toast.success('Yönetim paneline hoş geldiniz!');
+      const redirectTo =
+        (location.state as { from?: { pathname?: string } })?.from?.pathname ?? '/admin/dashboard';
+      navigate(redirectTo, { replace: true });
+    },
+    onError: (error: unknown) => {
+      if (error && typeof error === 'object' && 'response' in error) {
+        const message = (error as any).response?.data?.message ?? 'Giriş yapılamadı';
+        toast.error(message);
+      } else {
+        toast.error('Giriş yapılamadı');
+      }
+    }
+  });
+
+  const onSubmit = async (values: LoginFormValues) => {
+    await mutateAsync({
+      email: values.email,
+      password: values.password
+    });
+  };
+
+  return (
+    <div className="flex justify-center py-10">
+      <motion.div
+        className="w-full max-w-md"
+        initial={{ opacity: 0, y: 24 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.3 }}
+      >
+        <Card>
+          <CardHeader>
+            <CardTitle>Admin Girişi</CardTitle>
+            <CardDescription>Blog yönetim paneline erişmek için giriş yapın.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+              <div className="space-y-2">
+                <Label htmlFor="email">E-posta</Label>
+                <Input id="email" type="email" placeholder="ornek@mail.com" {...register('email')} />
+                {errors.email && <p className="text-sm text-destructive">{errors.email.message}</p>}
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="password">Şifre</Label>
+                <Input id="password" type="password" placeholder="********" {...register('password')} />
+                {errors.password && <p className="text-sm text-destructive">{errors.password.message}</p>}
+              </div>
+              <Button type="submit" className="w-full" disabled={isPending}>
+                {isPending ? 'Giriş yapılıyor...' : 'Giriş Yap'}
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+      </motion.div>
+    </div>
+  );
+}

--- a/clients/blogapp-client/src/providers/query-client.ts
+++ b/clients/blogapp-client/src/providers/query-client.ts
@@ -1,0 +1,11 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      staleTime: 1000 * 60,
+      refetchOnWindowFocus: false
+    }
+  }
+});

--- a/clients/blogapp-client/src/routes/protected-route.tsx
+++ b/clients/blogapp-client/src/routes/protected-route.tsx
@@ -7,7 +7,11 @@ interface ProtectedRouteProps {
 
 export function ProtectedRoute({ children }: ProtectedRouteProps) {
   const location = useLocation();
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, hydrated } = useAuth();
+
+  if (!hydrated) {
+    return null;
+  }
 
   if (!isAuthenticated) {
     return <Navigate to="/login" state={{ from: location }} replace />;

--- a/clients/blogapp-client/src/routes/protected-route.tsx
+++ b/clients/blogapp-client/src/routes/protected-route.tsx
@@ -1,0 +1,17 @@
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../hooks/use-auth';
+
+interface ProtectedRouteProps {
+  children: React.ReactNode;
+}
+
+export function ProtectedRoute({ children }: ProtectedRouteProps) {
+  const location = useLocation();
+  const { isAuthenticated } = useAuth();
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/clients/blogapp-client/src/routes/router.tsx
+++ b/clients/blogapp-client/src/routes/router.tsx
@@ -1,0 +1,51 @@
+import { Navigate, createBrowserRouter } from 'react-router-dom';
+import { PublicLayout } from '../components/layout/public-layout';
+import { HomePage } from '../pages/public/home-page';
+import { LoginPage } from '../pages/public/login-page';
+import { ProtectedRoute } from './protected-route';
+import { AdminLayout } from '../components/layout/admin-layout';
+import { DashboardPage } from '../pages/admin/dashboard-page';
+import { CategoriesPage } from '../pages/admin/categories-page';
+
+export const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <PublicLayout />,
+    children: [
+      {
+        index: true,
+        element: <HomePage />
+      },
+      {
+        path: 'login',
+        element: <LoginPage />
+      }
+    ]
+  },
+  {
+    path: '/admin',
+    element: (
+      <ProtectedRoute>
+        <AdminLayout />
+      </ProtectedRoute>
+    ),
+    children: [
+      {
+        index: true,
+        element: <Navigate to="dashboard" replace />
+      },
+      {
+        path: 'dashboard',
+        element: <DashboardPage />
+      },
+      {
+        path: 'categories',
+        element: <CategoriesPage />
+      }
+    ]
+  },
+  {
+    path: '*',
+    element: <Navigate to="/" replace />
+  }
+]);

--- a/clients/blogapp-client/src/stores/auth-store.ts
+++ b/clients/blogapp-client/src/stores/auth-store.ts
@@ -11,9 +11,11 @@ export interface AuthUser {
 interface AuthState {
   user: AuthUser | null;
   token: string | null;
+  hydrated: boolean;
   login: (payload: { user: AuthUser; token: string }) => void;
   logout: () => void;
   isAuthenticated: () => boolean;
+  setHydrated: (hydrated: boolean) => void;
 }
 
 export const useAuthStore = create<AuthState>()(
@@ -21,11 +23,15 @@ export const useAuthStore = create<AuthState>()(
     (set, get) => ({
       user: null,
       token: null,
+      hydrated: typeof window === 'undefined',
       login: ({ user, token }) => {
         set({ user, token });
       },
       logout: () => {
         set({ user: null, token: null });
+      },
+      setHydrated: (hydrated) => {
+        set({ hydrated });
       },
       isAuthenticated: () => {
         const state = get();
@@ -44,7 +50,11 @@ export const useAuthStore = create<AuthState>()(
     }),
     {
       name: 'blogapp-auth',
-      storage: createJSONStorage(() => localStorage)
+      storage: createJSONStorage(() => localStorage),
+      partialize: ({ user, token }) => ({ user, token }),
+      onRehydrateStorage: () => (state) => {
+        state?.setHydrated(true);
+      }
     }
   )
 );

--- a/clients/blogapp-client/src/stores/auth-store.ts
+++ b/clients/blogapp-client/src/stores/auth-store.ts
@@ -1,0 +1,50 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
+export interface AuthUser {
+  userId: number;
+  userName: string;
+  expiration: string;
+  refreshToken: string;
+}
+
+interface AuthState {
+  user: AuthUser | null;
+  token: string | null;
+  login: (payload: { user: AuthUser; token: string }) => void;
+  logout: () => void;
+  isAuthenticated: () => boolean;
+}
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set, get) => ({
+      user: null,
+      token: null,
+      login: ({ user, token }) => {
+        set({ user, token });
+      },
+      logout: () => {
+        set({ user: null, token: null });
+      },
+      isAuthenticated: () => {
+        const state = get();
+        if (!state.user || !state.token) {
+          return false;
+        }
+
+        const expiresAt = new Date(state.user.expiration).getTime();
+        if (Number.isNaN(expiresAt) || expiresAt <= Date.now()) {
+          set({ user: null, token: null });
+          return false;
+        }
+
+        return true;
+      }
+    }),
+    {
+      name: 'blogapp-auth',
+      storage: createJSONStorage(() => localStorage)
+    }
+  )
+);

--- a/clients/blogapp-client/src/types/api.ts
+++ b/clients/blogapp-client/src/types/api.ts
@@ -1,0 +1,69 @@
+export interface ApiResult<T = undefined> {
+  success: boolean;
+  message: string;
+  data: T;
+}
+
+export interface PaginatedListResponse<T> {
+  items: T[];
+  size: number;
+  index: number;
+  count: number;
+  pages: number;
+  hasPrevious: boolean;
+  hasNext: boolean;
+}
+
+export interface PaginatedRequest {
+  pageIndex: number;
+  pageSize: number;
+}
+
+export interface SortDescriptor {
+  field: string;
+  dir: 'asc' | 'desc';
+}
+
+export interface FilterDescriptor {
+  field: string;
+  operator: string;
+  value?: string | number | boolean;
+  logic?: string;
+  filters?: FilterDescriptor[];
+}
+
+export interface DataGridRequest {
+  paginatedRequest: PaginatedRequest;
+  dynamicQuery?: {
+    sort?: SortDescriptor[];
+    filter?: FilterDescriptor;
+  };
+}
+
+export function normalizeApiResult<T>(data: any): ApiResult<T> {
+  if (data && typeof data === 'object' && 'success' in data) {
+    return data as ApiResult<T>;
+  }
+
+  return {
+    success: Boolean(data?.Success),
+    message: data?.Message ?? '',
+    data: data?.Data as T
+  };
+}
+
+export function normalizePaginatedResponse<T>(data: any): PaginatedListResponse<T> {
+  if (data && typeof data === 'object' && 'items' in data) {
+    return data as PaginatedListResponse<T>;
+  }
+
+  return {
+    items: (data?.Items ?? []) as T[],
+    size: Number(data?.Size ?? data?.PageSize ?? 0),
+    index: Number(data?.Index ?? data?.PageIndex ?? 0),
+    count: Number(data?.Count ?? 0),
+    pages: Number(data?.Pages ?? 0),
+    hasPrevious: Boolean(data?.HasPrevious ?? false),
+    hasNext: Boolean(data?.HasNext ?? false)
+  };
+}

--- a/clients/blogapp-client/tailwind.config.ts
+++ b/clients/blogapp-client/tailwind.config.ts
@@ -1,0 +1,73 @@
+import type { Config } from 'tailwindcss';
+import animatePlugin from 'tailwindcss-animate';
+
+export default {
+  darkMode: ['class'],
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    container: {
+      center: true,
+      padding: '1.5rem',
+      screens: {
+        '2xl': '1280px'
+      }
+    },
+    extend: {
+      colors: {
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))'
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))'
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))'
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))'
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))'
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))'
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))'
+        }
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)'
+      },
+      keyframes: {
+        'accordion-down': {
+          from: { height: '0' },
+          to: { height: 'var(--radix-accordion-content-height)' }
+        },
+        'accordion-up': {
+          from: { height: 'var(--radix-accordion-content-height)' },
+          to: { height: '0' }
+        }
+      },
+      animation: {
+        'accordion-down': 'accordion-down 0.2s ease-out',
+        'accordion-up': 'accordion-up 0.2s ease-out'
+      }
+    }
+  },
+  plugins: [animatePlugin]
+} satisfies Config;

--- a/clients/blogapp-client/tsconfig.app.json
+++ b/clients/blogapp-client/tsconfig.app.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.cache/tsconfig.app.tsbuildinfo"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/clients/blogapp-client/tsconfig.base.json
+++ b/clients/blogapp-client/tsconfig.base.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  }
+}

--- a/clients/blogapp-client/tsconfig.json
+++ b/clients/blogapp-client/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.app.json" }
+  ]
+}

--- a/clients/blogapp-client/tsconfig.node.json
+++ b/clients/blogapp-client/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "noEmit": false,
+    "outDir": "./dist-node",
+    "tsBuildInfoFile": "./node_modules/.cache/tsconfig.node.tsbuildinfo"
+  },
+  "include": ["vite.config.ts", "tailwind.config.ts", "postcss.config.js"]
+}

--- a/clients/blogapp-client/vite.config.ts
+++ b/clients/blogapp-client/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: '0.0.0.0'
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React + TypeScript client with Tailwind, shadcn/ui, and supporting tooling for the BlogApp API
- implement routing, authentication store, axios interceptors, and shared public/admin layouts wired to the existing backend
- deliver home, login, and admin category management pages with React Query powered CRUD flows and UI polish

## Testing
- not run (npm install blocked by environment)

------
https://chatgpt.com/codex/tasks/task_e_68fa300190808320895c432c678c2709