### PR TITLE
Fix public post fetch and add dashboard home button

### DIFF
--- a/clients/blogapp-client/src/features/posts/api.ts
+++ b/clients/blogapp-client/src/features/posts/api.ts
@@ -12,7 +12,7 @@ export async function fetchPublishedPosts(pageIndex = 0, pageSize = 6) {
       Filter: {
         Field: 'IsPublished',
         Operator: 'eq',
-        Value: true
+        Value: String(true)
       },
       Sort: [
         {

--- a/clients/blogapp-client/src/pages/admin/dashboard-page.tsx
+++ b/clients/blogapp-client/src/pages/admin/dashboard-page.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../components/ui/card';
 import { Separator } from '../../components/ui/separator';
@@ -36,7 +37,12 @@ export function DashboardPage() {
             BlogApp içeriklerinizi kolayca yönetin, yeni kategoriler oluşturun ve gönderilerinizi düzenleyin. Sağ menüden ilgili alanlara hızlıca ulaşabilirsiniz.
           </p>
         </div>
-        <Button size="lg">Yeni Gönderi Oluştur</Button>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <Button size="lg">Yeni Gönderi Oluştur</Button>
+          <Button variant="outline" size="lg" asChild>
+            <Link to="/">Anasayfaya Dön</Link>
+          </Button>
+        </div>
       </motion.div>
 
       <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">


### PR DESCRIPTION
## Summary
- ensure the published posts query sends a string filter value compatible with the API
- add an "Anasayfaya Dön" action on the dashboard hero so admins can return to the public homepage easily

## Testing
- npm run build *(fails: existing TypeScript typing errors in categories page and axios interceptor)*

------
https://chatgpt.com/codex/tasks/task_e_68fb5a3eea94832088197b0d9a3a7c9c