### PR TITLE
Allow public access to posts and categories

### DIFF
--- a/src/BlogApp.API/Controllers/CategoryController.cs
+++ b/src/BlogApp.API/Controllers/CategoryController.cs
@@ -7,12 +7,14 @@ using BlogApp.Application.Features.Categories.Queries.GetPaginatedListByDynamic;
 using BlogApp.Domain.Common.Requests;
 using BlogApp.Domain.Common.Responses;
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace BlogApp.API.Controllers
 {
     public class CategoryController(IMediator mediator) : BaseApiController(mediator)
     {
+        [AllowAnonymous]
         [HttpPost("GetPaginatedList")]
         public async Task<IActionResult> GetPaginatedListByDynamic(DataGridRequest dataGridRequest)
         {
@@ -20,6 +22,7 @@ namespace BlogApp.API.Controllers
             return Ok(response);
         }
 
+        [AllowAnonymous]
         [HttpGet("GetAll")]
         public async Task<IActionResult> GetAll()
         {
@@ -27,6 +30,7 @@ namespace BlogApp.API.Controllers
             return Ok(response);
         }
 
+        [AllowAnonymous]
         [HttpGet("GetById/{id}")]
         public async Task<IActionResult> GetById([FromRoute] int id)
         {

--- a/src/BlogApp.API/Controllers/PostController.cs
+++ b/src/BlogApp.API/Controllers/PostController.cs
@@ -1,4 +1,3 @@
-using BlogApp.Application.Features.Categories.Queries.GetPaginatedListByDynamic;
 using BlogApp.Application.Features.Posts.Commands.Create;
 using BlogApp.Application.Features.Posts.Commands.Delete;
 using BlogApp.Application.Features.Posts.Commands.Update;
@@ -7,12 +6,14 @@ using BlogApp.Application.Features.Posts.Queries.GetPaginatedListByDynamic;
 using BlogApp.Domain.Common.Requests;
 using BlogApp.Domain.Common.Responses;
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace BlogApp.API.Controllers
 {
     public class PostController(IMediator mediator) : BaseApiController(mediator)
     {
+        [AllowAnonymous]
         [HttpPost("GetPaginatedList")]
         public async Task<IActionResult> GetPaginatedListByDynamic(DataGridRequest dataGridRequest)
         {
@@ -20,6 +21,7 @@ namespace BlogApp.API.Controllers
             return Ok(response);
         }
 
+        [AllowAnonymous]
         [HttpGet("GetById/{id}")]
         public async Task<IActionResult> GetById([FromRoute] int id)
         {


### PR DESCRIPTION
## Summary
- allow anonymous access to post listing endpoints so the homepage can load without authentication
- allow anonymous access to category listing endpoints so category data is available to unauthenticated visitors

## Testing
- dotnet test *(fails: dotnet not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68fb5e2306c48320a2b18bb444c26c1d