### PR TITLE
Fix admin categories query typing and axios header handling

### DIFF
--- a/clients/blogapp-client/.gitignore
+++ b/clients/blogapp-client/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 .DS_Store
 dist
+dist-node
 .env
 *.local

--- a/clients/blogapp-client/src/lib/axios.ts
+++ b/clients/blogapp-client/src/lib/axios.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { AxiosHeaders } from 'axios';
 import { useAuthStore } from '../stores/auth-store';
 
 const api = axios.create({
@@ -9,10 +9,9 @@ const api = axios.create({
 api.interceptors.request.use((config) => {
   const token = useAuthStore.getState().token;
   if (token) {
-    config.headers = {
-      ...config.headers,
-      Authorization: `Bearer ${token}`
-    };
+    const headers = AxiosHeaders.from(config.headers ?? {});
+    headers.set('Authorization', `Bearer ${token}`);
+    config.headers = headers;
   }
   return config;
 });

--- a/clients/blogapp-client/src/pages/admin/categories-page.tsx
+++ b/clients/blogapp-client/src/pages/admin/categories-page.tsx
@@ -16,6 +16,7 @@ import { fetchCategories, createCategory, updateCategory, deleteCategory } from 
 import {
   Category,
   CategoryFormValues,
+  CategoryListResponse,
   CategoryTableFilters
 } from '../../features/categories/types';
 import { Button } from '../../components/ui/button';
@@ -60,7 +61,7 @@ export function CategoriesPage() {
   const [editingCategory, setEditingCategory] = useState<Category | null>(null);
   const [categoryToDelete, setCategoryToDelete] = useState<Category | null>(null);
 
-  const categoriesQuery = useQuery({
+  const categoriesQuery = useQuery<CategoryListResponse>({
     queryKey: [
       'categories',
       filters.pageIndex,
@@ -70,7 +71,7 @@ export function CategoriesPage() {
       filters.sort?.dir ?? ''
     ],
     queryFn: () => fetchCategories(filters),
-    keepPreviousData: true
+    placeholderData: (previousData) => previousData
   });
 
   useEffect(() => {
@@ -87,7 +88,7 @@ export function CategoriesPage() {
       const nextSort = sortState
         ? {
             field: fieldMap[sortState.id] ?? sortState.id,
-            dir: sortState.desc ? 'desc' : 'asc'
+            dir: sortState.desc ? ('desc' as const) : ('asc' as const)
           }
         : undefined;
 


### PR DESCRIPTION
## Summary
- ensure axios interceptor sets authorization header via AxiosHeaders to satisfy axios v1 typings
- align admin categories query options with TanStack Query v5 and tighten sort typing
- ignore dist-node build output directory to avoid accidental commits

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fb6681524c8320993bf4cd4fda7819