### PR TITLE
Switch homepage posts to GetList endpoint

### DIFF
--- a/clients/blogapp-client/src/features/posts/api.ts
+++ b/clients/blogapp-client/src/features/posts/api.ts
@@ -3,26 +3,11 @@ import { normalizePaginatedResponse } from '../../types/api';
 import { PostListResponse, PostSummary } from './types';
 
 export async function fetchPublishedPosts(pageIndex = 0, pageSize = 6) {
-  const payload = {
-    PaginatedRequest: {
+  const response = await api.get<PostListResponse>('/Post/GetList', {
+    params: {
       PageIndex: pageIndex,
       PageSize: pageSize
-    },
-    DynamicQuery: {
-      Filter: {
-        Field: 'IsPublished',
-        Operator: 'eq',
-        Value: String(true)
-      },
-      Sort: [
-        {
-          Field: 'Id',
-          Dir: 'desc'
-        }
-      ]
     }
-  };
-
-  const response = await api.post<PostListResponse>('/Post/GetPaginatedList', payload);
+  });
   return normalizePaginatedResponse<PostSummary>(response.data);
 }

--- a/src/BlogApp.API/Controllers/PostController.cs
+++ b/src/BlogApp.API/Controllers/PostController.cs
@@ -3,16 +3,26 @@ using BlogApp.Application.Features.Posts.Commands.Create;
 using BlogApp.Application.Features.Posts.Commands.Delete;
 using BlogApp.Application.Features.Posts.Commands.Update;
 using BlogApp.Application.Features.Posts.Queries.GetById;
+using BlogApp.Application.Features.Posts.Queries.GetList;
 using BlogApp.Application.Features.Posts.Queries.GetPaginatedListByDynamic;
 using BlogApp.Domain.Common.Requests;
 using BlogApp.Domain.Common.Responses;
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace BlogApp.API.Controllers
 {
     public class PostController(IMediator mediator) : BaseApiController(mediator)
     {
+        [AllowAnonymous]
+        [HttpGet("GetList")]
+        public async Task<IActionResult> GetList([FromQuery] PaginatedRequest pageRequest)
+        {
+            PaginatedListResponse<GetListPostResponse> response = await Mediator.Send(new GetListPostQuery(pageRequest));
+            return Ok(response);
+        }
+
         [HttpPost("GetPaginatedList")]
         public async Task<IActionResult> GetPaginatedListByDynamic(DataGridRequest dataGridRequest)
         {

--- a/src/BlogApp.Application/Features/Posts/Profiles/PostProfile.cs
+++ b/src/BlogApp.Application/Features/Posts/Profiles/PostProfile.cs
@@ -30,6 +30,7 @@ public sealed class PostProfile : Profile
             .ReverseMap();
 
         CreateMap<Paginate<Post>, PaginatedListResponse<GetPaginatedListByDynamicPostsResponse>>().ReverseMap();
+        CreateMap<Paginate<Post>, PaginatedListResponse<GetListPostResponse>>().ReverseMap();
 
     }
 }

--- a/src/BlogApp.Application/Features/Posts/Queries/GetList/GetListPostQueryHandler.cs
+++ b/src/BlogApp.Application/Features/Posts/Queries/GetList/GetListPostQueryHandler.cs
@@ -1,4 +1,5 @@
-﻿using AutoMapper;
+using System.Linq;
+using AutoMapper;
 using BlogApp.Domain.Common.Paging;
 using BlogApp.Domain.Common.Responses;
 using BlogApp.Domain.Entities;
@@ -13,11 +14,13 @@ public sealed class GetListPostQueryHandler(IPostRepository postRepository, IMap
     public async Task<PaginatedListResponse<GetListPostResponse>> Handle(GetListPostQuery request, CancellationToken cancellationToken)
     {
         Paginate<Post> posts = await postRepository.GetPaginatedListAsync(
+            predicate: post => post.IsPublished,
+            orderBy: query => query.OrderByDescending(post => post.Id),
             index: request.PageRequest.PageIndex,
             include: p => p.Include(p => p.Category),
             size: request.PageRequest.PageSize,
             cancellationToken: cancellationToken
-       );
+        );
 
         PaginatedListResponse<GetListPostResponse> response = mapper.Map<PaginatedListResponse<GetListPostResponse>>(posts);
         return response;


### PR DESCRIPTION
## Summary
- expose an anonymous /Post/GetList endpoint that returns paginated published posts
- ensure post mappings support the new list response shape
- load homepage posts from the new endpoint on the client

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fb69255b0c832095072332366caca3