### PR TITLE
Ensure published posts refresh after admin updates

### DIFF
--- a/clients/blogapp-client/src/pages/admin/posts-page.tsx
+++ b/clients/blogapp-client/src/pages/admin/posts-page.tsx
@@ -251,6 +251,7 @@ export function PostsPage() {
       toast.success(result.message || 'Gönderi oluşturuldu');
       setIsCreateOpen(false);
       queryClient.invalidateQueries({ queryKey: ['posts'] });
+      queryClient.invalidateQueries({ queryKey: ['posts', 'published'] });
     },
     onError: () => toast.error('Gönderi oluşturulurken bir hata oluştu')
   });
@@ -266,6 +267,7 @@ export function PostsPage() {
       toast.success(result.message || 'Gönderi güncellendi');
       setEditingPost(null);
       queryClient.invalidateQueries({ queryKey: ['posts'] });
+      queryClient.invalidateQueries({ queryKey: ['posts', 'published'] });
     },
     onError: () => toast.error('Gönderi güncellenirken bir hata oluştu')
   });
@@ -280,6 +282,7 @@ export function PostsPage() {
       toast.success(result.message || 'Gönderi silindi');
       setPostToDelete(null);
       queryClient.invalidateQueries({ queryKey: ['posts'] });
+      queryClient.invalidateQueries({ queryKey: ['posts', 'published'] });
     },
     onError: () => toast.error('Gönderi silinirken bir hata oluştu')
   });

--- a/clients/blogapp-client/src/pages/public/home-page.tsx
+++ b/clients/blogapp-client/src/pages/public/home-page.tsx
@@ -6,8 +6,10 @@ import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
 
 export function HomePage() {
+  const publishedPostsQueryKey = ['posts', 'published', { pageIndex: 0, pageSize: 9 }] as const;
+
   const { data, isLoading, isError } = useQuery({
-    queryKey: [],
+    queryKey: publishedPostsQueryKey,
     queryFn: () => fetchPublishedPosts(0, 9)
   });
 


### PR DESCRIPTION
## Summary
- give the home page published posts query a stable key that can be invalidated
- invalidate the published posts query alongside the management list after create, update, or delete

## Testing
- npm run lint *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68fb75f3ab988320a32c241f84c1cbb3