### PR TITLE
feat: add dedicated create post page with unsaved warning

### DIFF
--- a/clients/blogapp-client/src/components/admin/admin-header.tsx
+++ b/clients/blogapp-client/src/components/admin/admin-header.tsx
@@ -1,4 +1,5 @@
-import { Menu, SunMoon } from 'lucide-react';
+import { Home, LogOut, Menu, SunMoon, UserCircle } from 'lucide-react';
+import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { Button } from '../ui/button';
 import { useAuth } from '../../hooks/use-auth';
@@ -27,15 +28,30 @@ export function AdminHeader({ onToggleSidebar, isCollapsed }: AdminHeaderProps) 
         </span>
       </div>
       <div className="flex items-center gap-3">
+        <Button variant="ghost" size="icon" asChild className="sm:hidden">
+          <Link to="/">
+            <Home className="h-5 w-5" />
+            <span className="sr-only">Anasayfaya Dön</span>
+          </Link>
+        </Button>
+        <Button variant="outline" size="sm" asChild className="hidden sm:flex">
+          <Link to="/">Anasayfaya Dön</Link>
+        </Button>
         <Button variant="ghost" size="icon">
           <SunMoon className="h-5 w-5" />
           <span className="sr-only">Tema Değiştir</span>
         </Button>
-        <div className="flex flex-col items-end text-sm">
-          <span className="font-medium">{user?.userName}</span>
-          <button className="text-xs text-muted-foreground hover:text-primary" onClick={logout}>
-            Çıkış Yap
-          </button>
+        <div className="flex items-center gap-2 rounded-full border bg-muted/40 px-3 py-1.5 text-sm shadow-sm">
+          <UserCircle className="h-5 w-5 text-primary" />
+          <span className="font-medium text-foreground">{user?.userName}</span>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={logout}
+            className="-mr-2 h-7 rounded-full border px-2 text-xs"
+          >
+            <LogOut className="mr-1 h-3.5 w-3.5" /> Çıkış Yap
+          </Button>
         </div>
       </div>
     </motion.header>

--- a/clients/blogapp-client/src/components/editor/rich-text-editor.tsx
+++ b/clients/blogapp-client/src/components/editor/rich-text-editor.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useRef } from 'react';
+import { Bold, Italic, List, ListOrdered, Underline, X } from 'lucide-react';
+
+import { Button } from '../ui/button';
+
+interface RichTextEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+export function RichTextEditor({ value, onChange, placeholder }: RichTextEditorProps) {
+  const editorRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!editorRef.current) {
+      return;
+    }
+
+    if (editorRef.current.innerHTML !== value) {
+      editorRef.current.innerHTML = value;
+    }
+  }, [value]);
+
+  const handleInput = () => {
+    const nextValue = editorRef.current?.innerHTML ?? '';
+    onChange(nextValue);
+  };
+
+  const applyCommand = (command: string) => {
+    if (!editorRef.current) {
+      return;
+    }
+
+    editorRef.current.focus();
+    document.execCommand(command);
+    handleInput();
+  };
+
+  const clearFormatting = () => {
+    if (!editorRef.current) {
+      return;
+    }
+
+    editorRef.current.focus();
+    document.execCommand('removeFormat');
+    document.execCommand('unlink');
+    handleInput();
+  };
+
+  return (
+    <div className="rounded-md border bg-background">
+      <div className="flex items-center gap-1 border-b bg-muted/30 px-2 py-1">
+        <Button type="button" variant="ghost" size="icon" onClick={() => applyCommand('bold')}>
+          <Bold className="h-4 w-4" />
+          <span className="sr-only">Kalın</span>
+        </Button>
+        <Button type="button" variant="ghost" size="icon" onClick={() => applyCommand('italic')}>
+          <Italic className="h-4 w-4" />
+          <span className="sr-only">İtalik</span>
+        </Button>
+        <Button type="button" variant="ghost" size="icon" onClick={() => applyCommand('underline')}>
+          <Underline className="h-4 w-4" />
+          <span className="sr-only">Altı Çizili</span>
+        </Button>
+        <Button type="button" variant="ghost" size="icon" onClick={() => applyCommand('insertUnorderedList')}>
+          <List className="h-4 w-4" />
+          <span className="sr-only">Sırasız Liste</span>
+        </Button>
+        <Button type="button" variant="ghost" size="icon" onClick={() => applyCommand('insertOrderedList')}>
+          <ListOrdered className="h-4 w-4" />
+          <span className="sr-only">Sıralı Liste</span>
+        </Button>
+        <Button type="button" variant="ghost" size="icon" onClick={clearFormatting}>
+          <X className="h-4 w-4" />
+          <span className="sr-only">Biçimlendirmeyi Temizle</span>
+        </Button>
+      </div>
+      <div className="relative">
+        {!value && placeholder ? (
+          <span className="pointer-events-none absolute left-3 top-2 text-sm text-muted-foreground">
+            {placeholder}
+          </span>
+        ) : null}
+        <div
+          ref={editorRef}
+          className="min-h-[200px] whitespace-pre-wrap px-3 py-2 text-sm focus:outline-none"
+          contentEditable
+          onInput={handleInput}
+          role="textbox"
+          aria-multiline="true"
+          suppressContentEditableWarning
+        />
+      </div>
+    </div>
+  );
+}

--- a/clients/blogapp-client/src/components/navigation/navbar.tsx
+++ b/clients/blogapp-client/src/components/navigation/navbar.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Link, NavLink } from 'react-router-dom';
-import { Menu, X } from 'lucide-react';
+import { LogOut, Menu, UserCircle, X } from 'lucide-react';
 import { Button } from '../ui/button';
 import { useAuth } from '../../hooks/use-auth';
 import { cn } from '../../lib/utils';
@@ -30,15 +30,24 @@ export function Navbar() {
             Anasayfa
           </NavLink>
           {isAuthenticated ? (
-            <>
+            <div className="flex items-center gap-3">
               <NavLink to="/admin/dashboard" className={navLinkClass}>
-                Admin
+                Admin Paneli
               </NavLink>
-              <span className="text-sm text-muted-foreground">{user?.userName}</span>
-              <Button variant="ghost" size="sm" onClick={handleLogout}>
-                Çıkış
+              <div className="flex items-center gap-2 rounded-full border bg-muted/40 px-3 py-1 text-sm shadow-sm">
+                <UserCircle className="h-4 w-4 text-primary" />
+                <span className="font-medium text-foreground">{user?.userName}</span>
+              </div>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={handleLogout}
+                className="h-9 w-9 rounded-full border"
+              >
+                <LogOut className="h-4 w-4" />
+                <span className="sr-only">Çıkış Yap</span>
               </Button>
-            </>
+            </div>
           ) : (
             <NavLink to="/login" className={navLinkClass}>
               Giriş
@@ -60,21 +69,33 @@ export function Navbar() {
               Anasayfa
             </NavLink>
             {isAuthenticated ? (
-              <>
+              <div className="flex flex-col gap-3">
                 <NavLink
                   to="/admin/dashboard"
                   className={navLinkClass}
                   onClick={() => setOpen(false)}
                 >
-                  Admin
+                  Admin Paneli
                 </NavLink>
-                <div className="flex items-center justify-between px-3 text-sm text-muted-foreground">
-                  <span>{user?.userName}</span>
-                  <Button variant="ghost" size="sm" onClick={handleLogout}>
-                    Çıkış
+                <div className="flex items-center justify-between rounded-xl border bg-muted/40 px-3 py-2">
+                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <UserCircle className="h-4 w-4 text-primary" />
+                    <span className="font-medium text-foreground">{user?.userName}</span>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-9 w-9 rounded-full border"
+                    onClick={() => {
+                      handleLogout();
+                      setOpen(false);
+                    }}
+                  >
+                    <LogOut className="h-4 w-4" />
+                    <span className="sr-only">Çıkış Yap</span>
                   </Button>
                 </div>
-              </>
+              </div>
             ) : (
               <NavLink to="/login" className={navLinkClass} onClick={() => setOpen(false)}>
                 Giriş

--- a/clients/blogapp-client/src/features/posts/schema.ts
+++ b/clients/blogapp-client/src/features/posts/schema.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+export const postSchema = z.object({
+  title: z.string().min(3, 'Başlık en az 3 karakter olmalıdır'),
+  summary: z.string().min(10, 'Özet en az 10 karakter olmalıdır'),
+  body: z.string().min(20, 'İçerik en az 20 karakter olmalıdır'),
+  thumbnail: z
+    .string()
+    .trim()
+    .refine(
+      (value) => value.length === 0 || /^https?:\/\/.+/i.test(value),
+      'Geçerli bir URL girin'
+    ),
+  isPublished: z.boolean(),
+  categoryId: z.number().int().positive('Kategori seçilmelidir')
+});
+
+export type PostFormSchema = z.infer<typeof postSchema>;

--- a/clients/blogapp-client/src/hooks/use-unsaved-changes-warning.ts
+++ b/clients/blogapp-client/src/hooks/use-unsaved-changes-warning.ts
@@ -1,0 +1,37 @@
+import { useEffect } from 'react';
+import { useBlocker } from 'react-router-dom';
+
+export function useUnsavedChangesWarning(shouldBlock: boolean, message: string) {
+  const blocker = useBlocker(shouldBlock);
+
+  useEffect(() => {
+    if (!shouldBlock) {
+      return;
+    }
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = message;
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [shouldBlock, message]);
+
+  useEffect(() => {
+    if (blocker.state !== 'blocked') {
+      return;
+    }
+
+    const confirmLeave = window.confirm(message);
+
+    if (confirmLeave) {
+      blocker.proceed();
+    } else {
+      blocker.reset();
+    }
+  }, [blocker, message]);
+}

--- a/clients/blogapp-client/src/pages/admin/create-post-page.tsx
+++ b/clients/blogapp-client/src/pages/admin/create-post-page.tsx
@@ -1,0 +1,240 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Controller, useForm } from 'react-hook-form';
+import toast from 'react-hot-toast';
+import { RichTextEditor } from '../../components/editor/rich-text-editor';
+
+import { Button } from '../../components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../components/ui/card';
+import { Input } from '../../components/ui/input';
+import { Label } from '../../components/ui/label';
+import { createPost } from '../../features/posts/api';
+import { postSchema, PostFormSchema } from '../../features/posts/schema';
+import { PostFormValues } from '../../features/posts/types';
+import { getAllCategories } from '../../features/categories/api';
+import { Category } from '../../features/categories/types';
+import { useUnsavedChangesWarning } from '../../hooks/use-unsaved-changes-warning';
+
+const textareaBaseClasses =
+  'flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50';
+
+const confirmMessage =
+  'Kaydedilmemiş değişiklikler var. Taslak olarak kaydetmeden çıkmak istediğinize emin misiniz?';
+
+export function CreatePostPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [hasSaved, setHasSaved] = useState(false);
+
+  const categoriesQuery = useQuery<Category[]>({
+    queryKey: ['categories-options'],
+    queryFn: getAllCategories
+  });
+
+  const defaultCategoryId = useMemo(() => categoriesQuery.data?.[0]?.id ?? 0, [categoriesQuery.data]);
+
+  const formMethods = useForm<PostFormSchema>({
+    resolver: zodResolver(postSchema),
+    defaultValues: {
+      title: '',
+      summary: '',
+      body: '',
+      thumbnail: '',
+      isPublished: false,
+      categoryId: defaultCategoryId
+    }
+  });
+
+  const {
+    handleSubmit,
+    register,
+    control,
+    watch,
+    formState,
+    setValue,
+    getValues,
+    reset
+  } = formMethods;
+
+  const isPublished = watch('isPublished');
+
+  useEffect(() => {
+    if (!categoriesQuery.data?.length) {
+      return;
+    }
+
+    if (getValues('categoryId') === 0) {
+      setValue('categoryId', categoriesQuery.data[0].id, { shouldDirty: false });
+    }
+  }, [categoriesQuery.data, getValues, setValue]);
+
+  const createMutation = useMutation({
+    mutationFn: (values: PostFormValues) => createPost(values),
+    onSuccess: async (result) => {
+      if (!result.success) {
+        toast.error(result.message || 'Gönderi oluşturulamadı');
+        return;
+      }
+
+      setHasSaved(true);
+      toast.success(result.message || 'Gönderi oluşturuldu');
+      await queryClient.invalidateQueries({ queryKey: ['posts'] });
+      await queryClient.invalidateQueries({ queryKey: ['posts', 'published'] });
+      reset({
+        title: '',
+        summary: '',
+        body: '',
+        thumbnail: '',
+        isPublished: false,
+        categoryId: categoriesQuery.data?.[0]?.id ?? 0
+      });
+      navigate('/admin/posts');
+    },
+    onError: () => toast.error('Gönderi oluşturulurken bir hata oluştu')
+  });
+
+  const shouldBlockNavigation = formState.isDirty && !hasSaved && !createMutation.isPending;
+  useUnsavedChangesWarning(shouldBlockNavigation, confirmMessage);
+
+  const onSubmit = handleSubmit(async (values) => {
+    await createMutation.mutateAsync(values);
+  });
+
+  const handleBack = () => {
+    if (shouldBlockNavigation && !window.confirm(confirmMessage)) {
+      return;
+    }
+
+    navigate('/admin/posts');
+  };
+
+  const submitLabel = createMutation.isPending
+    ? 'Kaydediliyor...'
+    : isPublished
+      ? 'Yayınla'
+      : 'Taslak Olarak Kaydet';
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 rounded-xl border bg-card p-6 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-2">
+          <h1 className="text-2xl font-semibold tracking-tight">Yeni Gönderi Oluştur</h1>
+          <p className="text-sm text-muted-foreground">
+            Gönderinizin detaylarını girin, ister hemen yayınlayın ister taslak olarak kaydedin.
+          </p>
+        </div>
+        <Button variant="outline" onClick={handleBack} className="self-start sm:self-auto">
+          Geri
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Gönderi Bilgileri</CardTitle>
+          <CardDescription>Başlık, özet ve içerik alanlarını doldurarak gönderinizi hazırlayın.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={onSubmit} className="space-y-6">
+            <div className="space-y-2">
+              <Label htmlFor="create-post-title">Başlık</Label>
+              <Input
+                id="create-post-title"
+                placeholder="Gönderi başlığı"
+                {...register('title')}
+              />
+              {formState.errors.title && (
+                <p className="text-sm text-destructive">{formState.errors.title.message}</p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="create-post-summary">Özet</Label>
+              <textarea
+                id="create-post-summary"
+                placeholder="Gönderinin kısa özetini yazın"
+                className={textareaBaseClasses + ' min-h-[120px]'}
+                {...register('summary')}
+              />
+              {formState.errors.summary && (
+                <p className="text-sm text-destructive">{formState.errors.summary.message}</p>
+              )}
+            </div>
+
+            <Controller
+              name="body"
+              control={control}
+              render={({ field }) => (
+                <div className="space-y-2">
+                  <Label>İçerik</Label>
+                  <RichTextEditor
+                    value={field.value}
+                    onChange={field.onChange}
+                    placeholder="Gönderi içeriğini yazmaya başlayın"
+                  />
+                  {formState.errors.body && (
+                    <p className="text-sm text-destructive">{formState.errors.body.message}</p>
+                  )}
+                </div>
+              )}
+            />
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="create-post-category">Kategori</Label>
+                <select
+                  id="create-post-category"
+                  className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                  {...register('categoryId', { valueAsNumber: true })}
+                >
+                  <option value={0} disabled>
+                    Kategori seçin
+                  </option>
+                  {categoriesQuery.data?.map((category) => (
+                    <option key={category.id} value={category.id}>
+                      {category.name}
+                    </option>
+                  ))}
+                </select>
+                {formState.errors.categoryId && (
+                  <p className="text-sm text-destructive">{formState.errors.categoryId.message}</p>
+                )}
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="create-post-thumbnail">Küçük Görsel URL</Label>
+                <Input
+                  id="create-post-thumbnail"
+                  placeholder="https://..."
+                  {...register('thumbnail')}
+                />
+                {formState.errors.thumbnail && (
+                  <p className="text-sm text-destructive">{formState.errors.thumbnail.message}</p>
+                )}
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-4 border-t pt-4 sm:flex-row sm:items-center sm:justify-between">
+              <label className="inline-flex items-center gap-2 text-sm font-medium">
+                <input
+                  type="checkbox"
+                  className="h-4 w-4 rounded border border-input"
+                  {...register('isPublished')}
+                />
+                Gönderiyi Yayınla
+              </label>
+              <div className="flex gap-2">
+                <Button type="button" variant="outline" onClick={handleBack}>
+                  Vazgeç
+                </Button>
+                <Button type="submit" disabled={createMutation.isPending}>
+                  {submitLabel}
+                </Button>
+              </div>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/clients/blogapp-client/src/pages/admin/dashboard-page.tsx
+++ b/clients/blogapp-client/src/pages/admin/dashboard-page.tsx
@@ -38,9 +38,8 @@ export function DashboardPage() {
           </p>
         </div>
         <div className="flex flex-col gap-2 sm:flex-row">
-          <Button size="lg">Yeni Gönderi Oluştur</Button>
-          <Button variant="outline" size="lg" asChild>
-            <Link to="/">Anasayfaya Dön</Link>
+          <Button size="lg" asChild>
+            <Link to="/admin/posts/new">Yeni Gönderi Oluştur</Link>
           </Button>
         </div>
       </motion.div>

--- a/clients/blogapp-client/src/pages/admin/posts-page.tsx
+++ b/clients/blogapp-client/src/pages/admin/posts-page.tsx
@@ -8,13 +8,12 @@ import {
 } from '@tanstack/react-table';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
+import { Link } from 'react-router-dom';
 import { PlusCircle, Pencil, Trash2, ArrowUpDown } from 'lucide-react';
-import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import {
   fetchPosts,
-  createPost,
   updatePost,
   deletePost
 } from '../../features/posts/api';
@@ -24,42 +23,18 @@ import {
   PostManagementListResponse,
   PostTableFilters
 } from '../../features/posts/types';
+import { postSchema, PostFormSchema } from '../../features/posts/schema';
 import { getAllCategories } from '../../features/categories/api';
 import { Category } from '../../features/categories/types';
 import { Button } from '../../components/ui/button';
 import { Input } from '../../components/ui/input';
 import { Label } from '../../components/ui/label';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../components/ui/table';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger
-} from '../../components/ui/dialog';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../../components/ui/dialog';
 import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card';
 import { Separator } from '../../components/ui/separator';
 import { Badge } from '../../components/ui/badge';
 import { cn } from '../../lib/utils';
-
-const postSchema = z.object({
-  title: z.string().min(3, 'Başlık en az 3 karakter olmalıdır'),
-  summary: z.string().min(10, 'Özet en az 10 karakter olmalıdır'),
-  body: z.string().min(20, 'İçerik en az 20 karakter olmalıdır'),
-  thumbnail: z
-    .string()
-    .trim()
-    .refine(
-      (value) => value.length === 0 || /^https?:\/\/.+/i.test(value),
-      'Geçerli bir URL girin'
-    ),
-  isPublished: z.boolean(),
-  categoryId: z.number().int().positive('Kategori seçilmelidir')
-});
-
-type PostFormSchema = z.infer<typeof postSchema>;
 
 const fieldMap: Record<string, string> = {
   id: 'Id',
@@ -81,7 +56,6 @@ export function PostsPage() {
   const [sorting, setSorting] = useState<SortingState>([
     { id: 'title', desc: false }
   ]);
-  const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [editingPost, setEditingPost] = useState<Post | null>(null);
   const [postToDelete, setPostToDelete] = useState<Post | null>(null);
 
@@ -241,21 +215,6 @@ export function PostsPage() {
     getCoreRowModel: getCoreRowModel()
   });
 
-  const createMutation = useMutation({
-    mutationFn: createPost,
-    onSuccess: (result) => {
-      if (!result.success) {
-        toast.error(result.message || 'Gönderi oluşturulamadı');
-        return;
-      }
-      toast.success(result.message || 'Gönderi oluşturuldu');
-      setIsCreateOpen(false);
-      queryClient.invalidateQueries({ queryKey: ['posts'] });
-      queryClient.invalidateQueries({ queryKey: ['posts', 'published'] });
-    },
-    onError: () => toast.error('Gönderi oluşturulurken bir hata oluştu')
-  });
-
   const updateMutation = useMutation({
     mutationFn: (values: PostFormValues) =>
       editingPost ? updatePost(editingPost.id, values) : Promise.reject(),
@@ -342,17 +301,9 @@ export function PostsPage() {
     }
   }, [editingPost, formMethods]);
 
-  useEffect(() => {
-    if (!editingPost && isCreateOpen) {
-      formMethods.reset(defaultFormValues);
-    }
-  }, [isCreateOpen, editingPost, defaultFormValues, formMethods]);
-
   const onSubmit = formMethods.handleSubmit(async (values) => {
     if (editingPost) {
       await updateMutation.mutateAsync(values);
-    } else {
-      await createMutation.mutateAsync(values);
     }
     formMethods.reset(defaultFormValues);
   });
@@ -372,112 +323,11 @@ export function PostsPage() {
               Gönderilerinizi oluşturun, düzenleyin ve yönetin. Arama, sıralama ve sayfalama özelliklerini kullanın.
             </p>
           </div>
-          <Dialog
-            open={isCreateOpen}
-            onOpenChange={(open) => {
-              setIsCreateOpen(open);
-              if (!open) {
-                formMethods.reset(defaultFormValues);
-              }
-            }}
-          >
-            <DialogTrigger asChild>
-              <Button className="gap-2">
-                <PlusCircle className="h-4 w-4" /> Yeni Gönderi
-              </Button>
-            </DialogTrigger>
-            <DialogContent className="max-w-3xl">
-              <DialogHeader>
-                <DialogTitle>Yeni Gönderi</DialogTitle>
-                <DialogDescription>Blogunuz için yeni bir gönderi oluşturun.</DialogDescription>
-              </DialogHeader>
-              <form id="create-post-form" onSubmit={onSubmit} className="space-y-4">
-                <div className="space-y-2">
-                  <Label htmlFor="post-title">Başlık</Label>
-                  <Input id="post-title" placeholder="Gönderi başlığı" {...formMethods.register('title')} />
-                  {formMethods.formState.errors.title && (
-                    <p className="text-sm text-destructive">{formMethods.formState.errors.title.message}</p>
-                  )}
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="post-summary">Özet</Label>
-                  <textarea
-                    id="post-summary"
-                    placeholder="Gönderinin kısa özeti"
-                    className={cn(textareaBaseClasses, 'min-h-[100px]')}
-                    {...formMethods.register('summary')}
-                  />
-                  {formMethods.formState.errors.summary && (
-                    <p className="text-sm text-destructive">{formMethods.formState.errors.summary.message}</p>
-                  )}
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="post-body">İçerik</Label>
-                  <textarea
-                    id="post-body"
-                    placeholder="Gönderi içeriğini yazın"
-                    className={cn(textareaBaseClasses, 'min-h-[180px]')}
-                    {...formMethods.register('body')}
-                  />
-                  {formMethods.formState.errors.body && (
-                    <p className="text-sm text-destructive">{formMethods.formState.errors.body.message}</p>
-                  )}
-                </div>
-                <div className="grid gap-4 sm:grid-cols-2">
-                  <div className="space-y-2">
-                    <Label htmlFor="post-category">Kategori</Label>
-                    <select
-                      id="post-category"
-                      className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                      {...formMethods.register('categoryId', { valueAsNumber: true })}
-                    >
-                      <option value={0} disabled>
-                        Kategori seçin
-                      </option>
-                      {categoriesQuery.data?.map((category) => (
-                        <option key={category.id} value={category.id}>
-                          {category.name}
-                        </option>
-                      ))}
-                    </select>
-                    {formMethods.formState.errors.categoryId && (
-                      <p className="text-sm text-destructive">{formMethods.formState.errors.categoryId.message}</p>
-                    )}
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="post-thumbnail">Küçük Görsel URL</Label>
-                    <Input
-                      id="post-thumbnail"
-                      placeholder="https://..."
-                      {...formMethods.register('thumbnail')}
-                    />
-                    {formMethods.formState.errors.thumbnail && (
-                      <p className="text-sm text-destructive">{formMethods.formState.errors.thumbnail.message}</p>
-                    )}
-                  </div>
-                </div>
-                <div className="flex items-center gap-2">
-                  <input
-                    id="post-isPublished"
-                    type="checkbox"
-                    className="h-4 w-4 rounded border border-input"
-                    {...formMethods.register('isPublished')}
-                  />
-                  <Label htmlFor="post-isPublished" className="text-sm font-medium">
-                    Gönderiyi yayınla
-                  </Label>
-                </div>
-              </form>
-              <DialogFooter className="gap-2">
-                <Button type="button" variant="ghost" onClick={() => setIsCreateOpen(false)}>
-                  İptal
-                </Button>
-                <Button type="submit" form="create-post-form" disabled={createMutation.isPending}>
-                  {createMutation.isPending ? 'Kaydediliyor...' : 'Kaydet'}
-                </Button>
-              </DialogFooter>
-            </DialogContent>
-          </Dialog>
+          <Button className="gap-2" asChild>
+            <Link to="/admin/posts/new">
+              <PlusCircle className="h-4 w-4" /> Yeni Gönderi
+            </Link>
+          </Button>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">

--- a/clients/blogapp-client/src/routes/router.tsx
+++ b/clients/blogapp-client/src/routes/router.tsx
@@ -7,6 +7,7 @@ import { AdminLayout } from '../components/layout/admin-layout';
 import { DashboardPage } from '../pages/admin/dashboard-page';
 import { CategoriesPage } from '../pages/admin/categories-page';
 import { PostsPage } from '../pages/admin/posts-page';
+import { CreatePostPage } from '../pages/admin/create-post-page';
 
 export const router = createBrowserRouter([
   {
@@ -46,6 +47,10 @@ export const router = createBrowserRouter([
       {
         path: 'posts',
         element: <PostsPage />
+      },
+      {
+        path: 'posts/new',
+        element: <CreatePostPage />
       }
     ]
   },


### PR DESCRIPTION
## Summary
- rename the admin navigation entry and refresh authenticated controls in the navbar and header
- move the home shortcut into the admin header and add a dedicated create post page with unsaved changes guard
- replace the modal-based post creation flow with a routed screen that uses a lightweight rich text editor

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fb7a154bc8832085158b9924241c0b