### PR TITLE
Improve API and client error handling

### DIFF
--- a/clients/blogapp-client/src/lib/api-error.ts
+++ b/clients/blogapp-client/src/lib/api-error.ts
@@ -1,0 +1,48 @@
+import toast from 'react-hot-toast';
+import { ApiError } from '../types/api';
+
+function isApiError(error: unknown): error is ApiError {
+  return Boolean(
+    error &&
+      typeof error === 'object' &&
+      'success' in error &&
+      'message' in error &&
+      (error as ApiError).success === false
+  );
+}
+
+export function getApiErrorMessage(error: unknown, fallbackMessage = 'Beklenmeyen bir hata oluştu'): string {
+  if (!error) {
+    return fallbackMessage;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  if (isApiError(error)) {
+    if (Array.isArray(error.errors) && error.errors.length > 0) {
+      return error.errors.filter(Boolean).join('\n');
+    }
+
+    if (error.message) {
+      return error.message;
+    }
+  }
+
+  if (typeof error === 'object' && 'message' in error && typeof (error as { message?: unknown }).message === 'string') {
+    return (error as { message?: string }).message || fallbackMessage;
+  }
+
+  if (error instanceof Error) {
+    return error.message || fallbackMessage;
+  }
+
+  return fallbackMessage;
+}
+
+export function handleApiError(error: unknown, fallbackMessage = 'Beklenmeyen bir hata oluştu'): string {
+  const message = getApiErrorMessage(error, fallbackMessage);
+  toast.error(message);
+  return message;
+}

--- a/clients/blogapp-client/src/lib/axios.ts
+++ b/clients/blogapp-client/src/lib/axios.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosHeaders } from 'axios';
+import { normalizeApiError } from '../types/api';
 import { useAuthStore } from '../stores/auth-store';
 
 const api = axios.create({
@@ -27,7 +28,8 @@ api.interceptors.response.use(
       }
     }
 
-    return Promise.reject(error);
+    const normalizedError = normalizeApiError(error, 'İsteğiniz işlenirken bir hata oluştu.');
+    return Promise.reject(normalizedError);
   }
 );
 

--- a/clients/blogapp-client/src/pages/admin/categories-page.tsx
+++ b/clients/blogapp-client/src/pages/admin/categories-page.tsx
@@ -7,7 +7,6 @@ import {
   useReactTable
 } from '@tanstack/react-table';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import toast from 'react-hot-toast';
 import { PlusCircle, Pencil, Trash2, ArrowUpDown } from 'lucide-react';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -34,6 +33,8 @@ import {
 } from '../../components/ui/dialog';
 import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card';
 import { Separator } from '../../components/ui/separator';
+import toast from 'react-hot-toast';
+import { handleApiError } from '../../lib/api-error';
 import { cn } from '../../lib/utils';
 
 const categorySchema = z.object({
@@ -180,7 +181,7 @@ export function CategoriesPage() {
       setIsCreateOpen(false);
       queryClient.invalidateQueries({ queryKey: ['categories'] });
     },
-    onError: () => toast.error('Kategori eklenirken bir hata oluştu')
+    onError: (error) => handleApiError(error, 'Kategori eklenemedi')
   });
 
   const updateMutation = useMutation({
@@ -195,7 +196,7 @@ export function CategoriesPage() {
       setEditingCategory(null);
       queryClient.invalidateQueries({ queryKey: ['categories'] });
     },
-    onError: () => toast.error('Kategori güncellenirken bir hata oluştu')
+    onError: (error) => handleApiError(error, 'Kategori güncellenemedi')
   });
 
   const deleteMutation = useMutation({
@@ -209,7 +210,7 @@ export function CategoriesPage() {
       setCategoryToDelete(null);
       queryClient.invalidateQueries({ queryKey: ['categories'] });
     },
-    onError: () => toast.error('Kategori silinirken bir hata oluştu')
+    onError: (error) => handleApiError(error, 'Kategori silinemedi')
   });
 
   const handlePageChange = (direction: 'prev' | 'next') => {

--- a/clients/blogapp-client/src/pages/admin/create-post-page.tsx
+++ b/clients/blogapp-client/src/pages/admin/create-post-page.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Controller, useForm } from 'react-hook-form';
-import toast from 'react-hot-toast';
 import { RichTextEditor } from '../../components/editor/rich-text-editor';
 
 import { Button } from '../../components/ui/button';
@@ -13,9 +12,11 @@ import { Label } from '../../components/ui/label';
 import { createPost } from '../../features/posts/api';
 import { postSchema, PostFormSchema } from '../../features/posts/schema';
 import { PostFormValues } from '../../features/posts/types';
+import toast from 'react-hot-toast';
 import { getAllCategories } from '../../features/categories/api';
 import { Category } from '../../features/categories/types';
 import { useUnsavedChangesWarning } from '../../hooks/use-unsaved-changes-warning';
+import { handleApiError } from '../../lib/api-error';
 
 const textareaBaseClasses =
   'flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50';
@@ -92,7 +93,7 @@ export function CreatePostPage() {
       });
       navigate('/admin/posts');
     },
-    onError: () => toast.error('Gönderi oluşturulurken bir hata oluştu')
+    onError: (error) => handleApiError(error, 'Gönderi oluşturulamadı')
   });
 
   const shouldBlockNavigation = formState.isDirty && !hasSaved && !createMutation.isPending;

--- a/clients/blogapp-client/src/pages/admin/posts-page.tsx
+++ b/clients/blogapp-client/src/pages/admin/posts-page.tsx
@@ -34,6 +34,7 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card';
 import { Separator } from '../../components/ui/separator';
 import { Badge } from '../../components/ui/badge';
+import { handleApiError } from '../../lib/api-error';
 import { cn } from '../../lib/utils';
 
 const fieldMap: Record<string, string> = {
@@ -228,7 +229,7 @@ export function PostsPage() {
       queryClient.invalidateQueries({ queryKey: ['posts'] });
       queryClient.invalidateQueries({ queryKey: ['posts', 'published'] });
     },
-    onError: () => toast.error('Gönderi güncellenirken bir hata oluştu')
+    onError: (error) => handleApiError(error, 'Gönderi güncellenemedi')
   });
 
   const deleteMutation = useMutation({
@@ -243,7 +244,7 @@ export function PostsPage() {
       queryClient.invalidateQueries({ queryKey: ['posts'] });
       queryClient.invalidateQueries({ queryKey: ['posts', 'published'] });
     },
-    onError: () => toast.error('Gönderi silinirken bir hata oluştu')
+    onError: (error) => handleApiError(error, 'Gönderi silinemedi')
   });
 
   const handlePageChange = (direction: 'prev' | 'next') => {

--- a/clients/blogapp-client/src/pages/public/login-page.tsx
+++ b/clients/blogapp-client/src/pages/public/login-page.tsx
@@ -3,7 +3,6 @@ import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation } from '@tanstack/react-query';
 import { useNavigate, useLocation } from 'react-router-dom';
-import toast from 'react-hot-toast';
 import { motion } from 'framer-motion';
 import { login } from '../../features/auth/api';
 import { useAuthStore } from '../../stores/auth-store';
@@ -11,6 +10,8 @@ import { Button } from '../../components/ui/button';
 import { Input } from '../../components/ui/input';
 import { Label } from '../../components/ui/label';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../components/ui/card';
+import toast from 'react-hot-toast';
+import { handleApiError } from '../../lib/api-error';
 
 const loginSchema = z.object({
   email: z.string().email('Geçerli bir e-posta adresi girin'),
@@ -60,12 +61,7 @@ export function LoginPage() {
       navigate(redirectTo, { replace: true });
     },
     onError: (error: unknown) => {
-      if (error && typeof error === 'object' && 'response' in error) {
-        const message = (error as any).response?.data?.message ?? 'Giriş yapılamadı';
-        toast.error(message);
-      } else {
-        toast.error('Giriş yapılamadı');
-      }
+      handleApiError(error, 'Giriş yapılamadı');
     }
   });
 

--- a/clients/blogapp-client/src/types/api.ts
+++ b/clients/blogapp-client/src/types/api.ts
@@ -2,6 +2,12 @@ export interface ApiResult<T = undefined> {
   success: boolean;
   message: string;
   data: T;
+  internalMessage?: string;
+  errors?: string[];
+}
+
+export interface ApiError extends ApiResult<undefined> {
+  statusCode?: number;
 }
 
 export interface PaginatedListResponse<T> {
@@ -45,7 +51,8 @@ export function normalizeApiResult<T>(data: any): ApiResult<T> {
     return {
       success: true,
       message: data,
-      data: undefined as T
+      data: undefined as T,
+      errors: []
     };
   }
 
@@ -53,11 +60,95 @@ export function normalizeApiResult<T>(data: any): ApiResult<T> {
     return data as ApiResult<T>;
   }
 
+  const collectedErrors: string[] = [];
+
+  const appendErrors = (errorSource: unknown) => {
+    if (!errorSource) {
+      return;
+    }
+
+    if (Array.isArray(errorSource)) {
+      collectedErrors.push(...(errorSource.filter((item) => typeof item === 'string') as string[]));
+      return;
+    }
+
+    if (typeof errorSource === 'object') {
+      Object.values(errorSource).forEach(appendErrors);
+    }
+  };
+
+  appendErrors(data?.Errors);
+  appendErrors(data?.errors);
+
+  const message = data?.Message ?? data?.message ?? collectedErrors[0] ?? '';
+
   return {
     success: Boolean(data?.Success),
-    message: data?.Message ?? '',
-    data: data?.Data as T
+    message,
+    data: data?.Data as T,
+    internalMessage: data?.InternalMessage ?? data?.internalMessage,
+    errors: collectedErrors.length > 0 ? collectedErrors : undefined
   };
+}
+
+export function normalizeApiError(error: unknown, fallbackMessage = 'Beklenmeyen bir hata oluştu'): ApiError {
+  const apiError: ApiError = {
+    success: false,
+    message: fallbackMessage,
+    data: undefined,
+    errors: [],
+    internalMessage: undefined,
+    statusCode: undefined
+  };
+
+  if (typeof error === 'string') {
+    apiError.message = error;
+    return apiError;
+  }
+
+  if (error && typeof error === 'object') {
+    const maybeAxiosError = error as {
+      message?: string;
+      response?: { status?: number; data?: any };
+      request?: unknown;
+    };
+
+    if (maybeAxiosError.response) {
+      apiError.statusCode = maybeAxiosError.response.status;
+      const data = maybeAxiosError.response.data;
+
+      if (typeof data === 'string') {
+        apiError.message = data;
+        return apiError;
+      }
+
+      if (data && typeof data === 'object') {
+        const normalized = normalizeApiResult(data);
+        apiError.message = normalized.message || fallbackMessage;
+        apiError.errors = normalized.errors ?? [];
+        apiError.internalMessage = normalized.internalMessage;
+        return apiError;
+      }
+    }
+
+    if (Array.isArray((error as { errors?: unknown }).errors)) {
+      const errors = (error as { errors: string[] }).errors;
+      apiError.errors = errors;
+      apiError.message = errors.join('\n') || fallbackMessage;
+      return apiError;
+    }
+
+    if (maybeAxiosError.message) {
+      apiError.message = maybeAxiosError.message;
+      return apiError;
+    }
+  }
+
+  if (error instanceof Error) {
+    apiError.message = error.message || fallbackMessage;
+  }
+
+  return apiError;
 }
 
 export function normalizePaginatedResponse<T>(data: any): PaginatedListResponse<T> {

--- a/src/BlogApp.API/Middlewares/ExceptionHandlingMiddleware.cs
+++ b/src/BlogApp.API/Middlewares/ExceptionHandlingMiddleware.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using BlogApp.Domain.Common.Results;
+using BlogApp.Domain.Exceptions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace BlogApp.API.Middlewares
+{
+    public class ExceptionHandlingMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly ILogger<ExceptionHandlingMiddleware> _logger;
+
+        public ExceptionHandlingMiddleware(RequestDelegate next, ILogger<ExceptionHandlingMiddleware> logger)
+        {
+            _next = next;
+            _logger = logger;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            try
+            {
+                await _next(context);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unhandled exception while processing the request");
+                await HandleExceptionAsync(context, ex);
+            }
+        }
+
+        private static async Task HandleExceptionAsync(HttpContext context, Exception exception)
+        {
+            var response = context.Response;
+            response.ContentType = "application/json";
+
+            var apiResult = new ApiResult<object>
+            {
+                Success = false,
+                Message = "İsteğiniz işlenirken bir hata oluştu.",
+                InternalMessage = exception.Message,
+                Errors = new List<string>()
+            };
+
+            response.StatusCode = exception switch
+            {
+                ValidationException validationException => BuildValidationError(validationException, apiResult),
+                BadRequestException => SetApiResult(apiResult, StatusCodes.Status400BadRequest, exception.Message),
+                NotFoundException => SetApiResult(apiResult, StatusCodes.Status404NotFound, exception.Message),
+                AuthenticationErrorException => SetApiResult(
+                    apiResult,
+                    StatusCodes.Status401Unauthorized,
+                    string.IsNullOrWhiteSpace(exception.Message)
+                        ? "Kimlik doğrulama başarısız."
+                        : exception.Message),
+                PasswordChangeFailedException => SetApiResult(apiResult, StatusCodes.Status400BadRequest, exception.Message),
+                InvalidOperationException => SetApiResult(apiResult, StatusCodes.Status400BadRequest, exception.Message),
+                ArgumentException => SetApiResult(apiResult, StatusCodes.Status400BadRequest, exception.Message),
+                _ => SetApiResult(apiResult, StatusCodes.Status500InternalServerError, "Beklenmeyen bir hata oluştu. Lütfen daha sonra tekrar deneyin.")
+            };
+
+            await response.WriteAsJsonAsync(apiResult);
+        }
+
+        private static int BuildValidationError(ValidationException validationException, ApiResult<object> apiResult)
+        {
+            apiResult.Message = validationException.Errors.FirstOrDefault() ?? "Geçersiz veya eksik bilgiler mevcut.";
+            apiResult.Errors = validationException.Errors;
+            return StatusCodes.Status400BadRequest;
+        }
+
+        private static int SetApiResult(ApiResult<object> apiResult, int statusCode, string message)
+        {
+            apiResult.Message = string.IsNullOrWhiteSpace(message)
+                ? "İsteğiniz işlenirken bir hata oluştu."
+                : message;
+            return statusCode;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add global exception handling middleware and custom model validation responses that return consistent ApiResult payloads
- extend the shared API types plus axios interceptor to normalize backend errors for the client
- use a centralized API error helper in mutations so validation feedback is surfaced to end users

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fb800bc0008320959b87f321714dd0