### PR TITLE
Redirect post editing to full page

### DIFF
--- a/clients/blogapp-client/src/features/posts/api.ts
+++ b/clients/blogapp-client/src/features/posts/api.ts
@@ -107,7 +107,16 @@ export async function deletePost(id: number) {
   return normalizeApiResult(response.data);
 }
 
-export async function getPostById(id: number) {
-  const response = await api.get<Post>(`/Post/GetById/${id}`);
-  return response.data;
+export async function getPostById(id: number): Promise<Post> {
+  const response = await api.get<ApiResult<Post>>(`/Post/GetById/${id}`);
+  const result = normalizeApiResult<Post>(response.data);
+
+  if (!result.success || !result.data) {
+    throw {
+      ...result,
+      success: false
+    };
+  }
+
+  return result.data;
 }

--- a/clients/blogapp-client/src/features/posts/api.ts
+++ b/clients/blogapp-client/src/features/posts/api.ts
@@ -106,3 +106,8 @@ export async function deletePost(id: number) {
   const response = await api.delete<ApiResult>(`/Post/Delete/${id}`);
   return normalizeApiResult(response.data);
 }
+
+export async function getPostById(id: number) {
+  const response = await api.get<Post>(`/Post/GetById/${id}`);
+  return response.data;
+}

--- a/clients/blogapp-client/src/routes/router.tsx
+++ b/clients/blogapp-client/src/routes/router.tsx
@@ -51,6 +51,10 @@ export const router = createBrowserRouter([
       {
         path: 'posts/new',
         element: <CreatePostPage />
+      },
+      {
+        path: 'posts/:postId/edit',
+        element: <CreatePostPage />
       }
     ]
   },


### PR DESCRIPTION
## Summary
- remove the inline edit modal from the post list and redirect edits to the dedicated post form page
- extend the post creation page to support loading and updating existing posts from the API
- add a client helper for retrieving individual posts and wire up routing for the edit screen

## Testing
- npm run lint *(fails: ESLint configuration file not found in project)*

------
https://chatgpt.com/codex/tasks/task_e_68fb845ea37c8320a431fa3f0532abe2