### PR TITLE
feat: add category-specific post listing

### DIFF
--- a/clients/blogapp-client/src/components/posts/post-card.tsx
+++ b/clients/blogapp-client/src/components/posts/post-card.tsx
@@ -1,0 +1,96 @@
+import { Link } from 'react-router-dom';
+import { ArrowRight } from 'lucide-react';
+import { Card } from '../ui/card';
+import { Badge } from '../ui/badge';
+import { cn } from '../../lib/utils';
+import type { PostSummary } from '../../features/posts/types';
+
+interface PostCardProps {
+  post: PostSummary;
+  variant?: 'default' | 'horizontal';
+}
+
+export function PostCard({ post, variant = 'default' }: PostCardProps) {
+  const hasThumbnail = Boolean(post.thumbnail);
+
+  return (
+    <Link to={`/posts/${post.id}`} className="group block h-full">
+      <Card
+        className={cn(
+          'flex h-full flex-col overflow-hidden rounded-3xl border border-border/60 bg-card/80 shadow-sm ring-1 ring-transparent transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl hover:ring-primary/20',
+          variant === 'horizontal' && 'md:flex-row'
+        )}
+      >
+        {hasThumbnail ? (
+          <div
+            className={cn(
+              'relative overflow-hidden',
+              variant === 'horizontal' ? 'md:w-2/5' : 'h-52 w-full'
+            )}
+          >
+            <img
+              src={post.thumbnail}
+              alt={post.title}
+              className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+            />
+            <div className="absolute inset-0 bg-gradient-to-t from-background/80 via-background/10 to-transparent opacity-0 transition-opacity duration-500 group-hover:opacity-100" />
+          </div>
+        ) : (
+          <div
+            className={cn(
+              'flex items-center justify-center bg-gradient-to-br from-primary/20 via-background to-secondary/30 text-primary',
+              variant === 'horizontal' ? 'md:w-2/5' : 'h-52 w-full'
+            )}
+          >
+            <span className="text-sm font-medium tracking-wide">BlogApp</span>
+          </div>
+        )}
+
+        <div
+          className={cn(
+            'flex flex-1 flex-col justify-between gap-6 p-6',
+            variant === 'horizontal' ? 'md:p-8' : 'md:p-7'
+          )}
+        >
+          <div className="space-y-4">
+            <Badge variant="secondary" className="w-fit rounded-full bg-secondary/70 px-3 py-1 text-xs">
+              {post.categoryName}
+            </Badge>
+            <h3 className="text-2xl font-semibold leading-snug tracking-tight text-foreground transition-colors group-hover:text-primary">
+              {post.title}
+            </h3>
+            <p className="line-clamp-3 text-sm text-muted-foreground md:text-base">
+              {post.summary}
+            </p>
+          </div>
+          <div className="flex items-center gap-2 text-sm font-medium text-primary">
+            Devamını Oku
+            <ArrowRight className="h-4 w-4 transition-transform duration-300 group-hover:translate-x-1" />
+          </div>
+        </div>
+      </Card>
+    </Link>
+  );
+}
+
+export function PostCardSkeleton({ variant = 'default' }: { variant?: 'default' | 'horizontal' }) {
+  return (
+    <div
+      className={cn(
+        'flex h-full animate-pulse flex-col overflow-hidden rounded-3xl border border-border/60 bg-muted/30',
+        variant === 'horizontal' && 'md:flex-row'
+      )}
+    >
+      <div className={cn(variant === 'horizontal' ? 'md:w-2/5' : 'h-52 w-full', 'bg-muted')} />
+      <div className="flex flex-1 flex-col justify-between gap-6 p-6">
+        <div className="space-y-4">
+          <div className="h-3 w-20 rounded-full bg-muted" />
+          <div className="h-6 w-3/4 rounded-full bg-muted" />
+          <div className="h-3 w-full rounded-full bg-muted" />
+          <div className="h-3 w-5/6 rounded-full bg-muted" />
+        </div>
+        <div className="h-3 w-24 rounded-full bg-muted" />
+      </div>
+    </div>
+  );
+}

--- a/clients/blogapp-client/src/features/posts/api.ts
+++ b/clients/blogapp-client/src/features/posts/api.ts
@@ -59,12 +59,29 @@ function buildPostDataGridPayload(filters: PostTableFilters) {
   return payload;
 }
 
-export async function fetchPublishedPosts(pageIndex = 0, pageSize = 6) {
-  const response = await api.get<PostListResponse>('/Post/GetList', {
-    params: {
-      PageIndex: pageIndex,
-      PageSize: pageSize
-    }
+export interface FetchPublishedPostsParams {
+  pageIndex?: number;
+  pageSize?: number;
+  categoryId?: number;
+}
+
+export async function fetchPublishedPosts({
+  pageIndex = 0,
+  pageSize = 6,
+  categoryId
+}: FetchPublishedPostsParams = {}) {
+  const endpoint = categoryId != null ? '/Post/GetListByCategoryId' : '/Post/GetList';
+  const params: Record<string, number> = {
+    PageIndex: pageIndex,
+    PageSize: pageSize
+  };
+
+  if (categoryId != null) {
+    params.CategoryId = categoryId;
+  }
+
+  const response = await api.get<PostListResponse>(endpoint, {
+    params
   });
 
   return normalizePaginatedResponse<PostSummary>(response.data);

--- a/clients/blogapp-client/src/pages/public/home-page.tsx
+++ b/clients/blogapp-client/src/pages/public/home-page.tsx
@@ -1,116 +1,207 @@
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { motion } from 'framer-motion';
+import { ArrowRight, Sparkles } from 'lucide-react';
 import { fetchPublishedPosts } from '../../features/posts/api';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../components/ui/card';
+import { getAllCategories } from '../../features/categories/api';
 import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
+import { PostCard, PostCardSkeleton } from '../../components/posts/post-card';
 
 export function HomePage() {
-  const publishedPostsQueryKey = ['posts', 'published', { pageIndex: 0, pageSize: 9 }] as const;
+  const [activeCategory, setActiveCategory] = useState<number | null>(null);
 
-  const { data, isLoading, isError } = useQuery({
-    queryKey: publishedPostsQueryKey,
-    queryFn: () => fetchPublishedPosts(0, 9)
+  const { data: categories, isLoading: isCategoriesLoading } = useQuery({
+    queryKey: ['categories', 'all'],
+    queryFn: getAllCategories
   });
 
+  const {
+    data: posts,
+    isLoading: isPostsLoading,
+    isError: isPostsError
+  } = useQuery({
+    queryKey: ['posts', 'published', { pageIndex: 0, pageSize: 12, categoryId: activeCategory ?? undefined }],
+    queryFn: () => fetchPublishedPosts({ pageIndex: 0, pageSize: 12, categoryId: activeCategory ?? undefined })
+  });
+
+  const categoryOptions = useMemo(
+    () => [
+      { id: null as number | null, name: 'Tümü' },
+      ...(categories?.map((category) => ({ id: category.id, name: category.name })) ?? [])
+    ],
+    [categories]
+  );
+
+  const activeCategoryName = useMemo(
+    () => categoryOptions.find((option) => option.id === activeCategory)?.name ?? 'Tümü',
+    [activeCategory, categoryOptions]
+  );
+
+  const postItems = posts?.items ?? [];
+  const featuredPost = postItems[0];
+  const spotlightPosts = postItems.slice(1, 3);
+  const remainingPosts = postItems.slice(3);
+
   return (
-    <div className="space-y-10">
-      <section className="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
-        <div className="space-y-4">
-          <motion.h1
-            className="text-3xl font-bold tracking-tight sm:text-4xl"
-            initial={{ y: 10, opacity: 0 }}
-            animate={{ y: 0, opacity: 1 }}
-            transition={{ delay: 0.1 }}
-          >
-            En Yeni Hikayelerle İlham Alın
-          </motion.h1>
-          <motion.p
-            className="text-lg text-muted-foreground"
-            initial={{ y: 10, opacity: 0 }}
-            animate={{ y: 0, opacity: 1 }}
-            transition={{ delay: 0.2 }}
-          >
-            BlogApp, teknoloji, tasarım ve üretkenlik dünyasından en güncel içerikleri
-            sunar. Topluluğumuza katılın ve uzmanlardan öğrenin.
-          </motion.p>
+    <div className="space-y-16">
+      <section className="relative overflow-hidden rounded-[2.75rem] border border-border/50 bg-gradient-to-br from-primary/10 via-background to-secondary/10 shadow-2xl">
+        <div className="absolute -top-24 left-1/2 h-64 w-64 -translate-x-1/2 rounded-full bg-primary/20 blur-3xl" aria-hidden />
+        <div className="absolute -bottom-16 -right-12 h-72 w-72 rounded-full bg-secondary/20 blur-3xl" aria-hidden />
+        <div className="relative grid gap-12 px-8 py-14 sm:px-12 lg:grid-cols-[minmax(0,1fr)_minmax(0,360px)] lg:px-16">
           <motion.div
-            initial={{ y: 10, opacity: 0 }}
+            className="space-y-8"
+            initial={{ y: 12, opacity: 0 }}
             animate={{ y: 0, opacity: 1 }}
-            transition={{ delay: 0.3 }}
+            transition={{ duration: 0.4 }}
           >
-            <Button size="lg">Keşfetmeye Başla</Button>
+            <div className="inline-flex items-center gap-2 rounded-full border border-primary/40 bg-primary/10 px-4 py-1 text-sm font-medium text-primary">
+              <Sparkles className="h-4 w-4" />
+              Yeni nesil blog deneyimi
+            </div>
+            <h1 className="text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
+              İlham verici hikayelerle modern ve sade bir deneyim
+            </h1>
+            <p className="max-w-2xl text-lg text-muted-foreground">
+              BlogApp topluluğu; teknoloji, tasarım ve üretkenlik alanlarındaki en güncel içerikleri buluşturur.
+              Kategoriler arasında dolaşarak merak ettiğiniz konuları keşfedin.
+            </p>
+            <div className="flex flex-wrap items-center gap-4">
+              <Button size="lg" asChild>
+                <a href="#posts" className="inline-flex items-center gap-2">
+                  Yazıları Keşfet
+                  <ArrowRight className="h-4 w-4" />
+                </a>
+              </Button>
+              <Badge variant="outline" className="rounded-full px-4 py-2 text-sm">
+                Seçili kategori: {activeCategoryName}
+              </Badge>
+            </div>
+          </motion.div>
+
+          <motion.div
+            className="relative overflow-hidden rounded-3xl border border-border/40 bg-background/80 p-8 shadow-lg backdrop-blur"
+            initial={{ opacity: 0, scale: 0.96 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ delay: 0.1, duration: 0.4 }}
+          >
+            <div className="absolute inset-0 bg-gradient-to-br from-primary/20 via-transparent to-secondary/30" aria-hidden />
+            <div className="relative z-10 flex h-full flex-col justify-between gap-6">
+              <div className="space-y-4">
+                <Badge className="w-fit rounded-full bg-primary/80 px-4 py-1 text-xs uppercase tracking-wider text-primary-foreground">
+                  Günün önerisi
+                </Badge>
+                <h2 className="text-2xl font-semibold text-foreground">
+                  {featuredPost ? featuredPost.title : 'Trend olan içerikler burada'}
+                </h2>
+                <p className="text-sm text-muted-foreground">
+                  {featuredPost
+                    ? featuredPost.summary
+                    : 'En çok ilgi gören yazıları keşfedin, yeni fikirler edinin ve üretkenliğinizi artırın.'}
+                </p>
+              </div>
+              <div>
+                {featuredPost ? (
+                  <Button variant="ghost" className="group h-auto px-0 text-primary" asChild>
+                    <Link to={`/posts/${featuredPost.id}`} className="inline-flex items-center gap-2">
+                      En popüler yazıyı incele
+                      <ArrowRight className="h-4 w-4 transition-transform duration-300 group-hover:translate-x-1" />
+                    </Link>
+                  </Button>
+                ) : (
+                  <p className="text-sm text-muted-foreground">
+                    Yeni içerikler eklendikçe bu alan sizin için öneriler sunar.
+                  </p>
+                )}
+              </div>
+            </div>
           </motion.div>
         </div>
-        <motion.div
-          className="relative hidden rounded-3xl border bg-gradient-to-br from-primary/10 to-secondary/10 p-8 lg:flex lg:flex-col lg:justify-between"
-          initial={{ opacity: 0, scale: 0.98 }}
-          animate={{ opacity: 1, scale: 1 }}
-        >
-          <div>
-            <Badge variant="secondary">Trend Konu</Badge>
-            <h2 className="mt-4 text-2xl font-semibold">Yapay Zeka ile Üretkenlik</h2>
-            <p className="mt-2 text-sm text-muted-foreground">
-              Modern iş akışlarında yapay zekanın rolü ve geleceğin yetenekleri üzerine derinlemesine analiz.
-            </p>
-          </div>
-          <div className="mt-6 text-sm text-muted-foreground">
-            Her hafta onlarca yeni makale yayımlanıyor. Haber bültenimize abone olun.
-          </div>
-        </motion.div>
       </section>
 
-      <section className="space-y-6">
-        <div className="flex items-center justify-between">
-          <h2 className="text-2xl font-semibold">Öne Çıkan Yazılar</h2>
-          <Button variant="ghost" size="sm">
-            Tüm Yazılar
-          </Button>
+      <section className="space-y-10" id="posts">
+        <div className="flex flex-wrap items-end justify-between gap-6">
+          <div className="space-y-2">
+            <h2 className="text-3xl font-semibold tracking-tight text-foreground">Öne çıkan yazılar</h2>
+            <p className="text-muted-foreground">
+              {activeCategory === null
+                ? 'Tüm kategorilerden en yeni içerikleri keşfedin.'
+                : `${activeCategoryName} kategorisindeki güncel gönderileri keşfedin.`}
+            </p>
+          </div>
+          <div className="flex items-center gap-3 text-sm text-muted-foreground">
+            <span className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border/60 bg-background font-semibold text-foreground">
+              {posts?.count ?? 0}
+            </span>
+            toplam yayınlanmış yazı
+          </div>
         </div>
-        {isError && (
-          <p className="text-sm text-destructive">Gönderiler yüklenirken bir hata oluştu.</p>
-        )}
-        <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
-          {isLoading &&
-            Array.from({ length: 6 }).map((_, index) => (
-              <div key={index} className="h-56 animate-pulse rounded-xl bg-muted" />
-            ))}
-          {!isLoading && data?.items.length === 0 && (
-            <p className="text-sm text-muted-foreground">Henüz yayınlanmış gönderi bulunmuyor.</p>
-          )}
-          {data?.items.map((post, index) => (
-            <motion.article
-              key={post.title}
-              initial={{ opacity: 0, y: 12 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: index * 0.05 }}
-            >
-              <Card className="h-full overflow-hidden">
-                {post.thumbnail && (
-                  <div className="h-40 w-full overflow-hidden">
-                    <img
-                      src={post.thumbnail}
-                      alt={post.title}
-                      className="h-full w-full object-cover transition-transform duration-300 hover:scale-105"
-                    />
-                  </div>
-                )}
-                <CardHeader className="space-y-2">
-                  <Badge variant="outline">{post.categoryName}</Badge>
-                  <CardTitle className="line-clamp-2 text-xl">{post.title}</CardTitle>
-                  <CardDescription className="line-clamp-3 text-sm">
-                    {post.summary}
-                  </CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <Button variant="link" className="px-0">
-                    Devamını Oku
+
+        <div className="flex flex-wrap gap-3">
+          {isCategoriesLoading
+            ? Array.from({ length: 6 }).map((_, index) => (
+                <div key={index} className="h-10 w-24 animate-pulse rounded-full bg-muted/60" />
+              ))
+            : categoryOptions.map((option) => {
+                const isActive = option.id === activeCategory;
+                return (
+                  <Button
+                    key={option.id ?? 'all'}
+                    variant={isActive ? 'default' : 'outline'}
+                    className="rounded-full border border-border/60 bg-background/80 text-sm font-medium transition-colors hover:border-primary"
+                    type="button"
+                    aria-pressed={isActive}
+                    onClick={() => setActiveCategory(option.id)}
+                  >
+                    {option.name}
                   </Button>
-                </CardContent>
-              </Card>
-            </motion.article>
-          ))}
+                );
+              })}
         </div>
+
+        {isPostsError && (
+          <div className="rounded-2xl border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
+            Gönderiler yüklenirken bir sorun oluştu. Lütfen daha sonra tekrar deneyin.
+          </div>
+        )}
+
+        {isPostsLoading ? (
+          <div className="space-y-8">
+            <PostCardSkeleton variant="horizontal" />
+            <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+              {Array.from({ length: 6 }).map((_, index) => (
+                <PostCardSkeleton key={index} />
+              ))}
+            </div>
+          </div>
+        ) : postItems.length === 0 ? (
+          <div className="rounded-3xl border border-border/50 bg-muted/20 p-10 text-center text-muted-foreground">
+            Bu kategoride henüz yayınlanmış gönderi bulunmuyor. Çok yakında yeni içerikler eklenecek!
+          </div>
+        ) : (
+          <div className="space-y-10">
+            {featuredPost && (
+              <PostCard key={featuredPost.id} post={featuredPost} variant="horizontal" />
+            )}
+
+            {spotlightPosts.length > 0 && (
+              <div className="grid gap-6 md:grid-cols-2">
+                {spotlightPosts.map((post) => (
+                  <PostCard key={post.id} post={post} variant="horizontal" />
+                ))}
+              </div>
+            )}
+
+            {remainingPosts.length > 0 && (
+              <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
+                {remainingPosts.map((post) => (
+                  <PostCard key={post.id} post={post} />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
       </section>
     </div>
   );

--- a/clients/blogapp-client/src/pages/public/post-detail-page.tsx
+++ b/clients/blogapp-client/src/pages/public/post-detail-page.tsx
@@ -1,0 +1,129 @@
+import { useMemo } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { motion } from 'framer-motion';
+import { ArrowLeft } from 'lucide-react';
+import { getPostById } from '../../features/posts/api';
+import { Badge } from '../../components/ui/badge';
+import { Button } from '../../components/ui/button';
+
+export function PostDetailPage() {
+  const { postId } = useParams();
+  const numericId = Number(postId);
+  const isValidId = Number.isInteger(numericId) && numericId > 0;
+
+  const {
+    data: post,
+    isLoading,
+    isError
+  } = useQuery({
+    queryKey: ['posts', 'detail', numericId],
+    queryFn: () => getPostById(numericId),
+    enabled: isValidId
+  });
+
+  const contentBlocks = useMemo(() => {
+    if (!post?.body) {
+      return [];
+    }
+
+    return post.body
+      .split(/\n{2,}/)
+      .map((paragraph) => paragraph.trim())
+      .filter(Boolean);
+  }, [post?.body]);
+
+  if (!isValidId) {
+    return (
+      <div className="mx-auto max-w-2xl space-y-6 text-center">
+        <h1 className="text-3xl font-semibold">Gönderi bulunamadı</h1>
+        <p className="text-muted-foreground">
+          Üzgünüz, aradığınız gönderiye erişilemedi. Lütfen tekrar deneyin ya da ana sayfaya dönün.
+        </p>
+        <Button asChild>
+          <Link to="/">Ana sayfaya dön</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-10">
+        <div className="h-72 animate-pulse rounded-[2.75rem] bg-muted/40" />
+        <div className="mx-auto max-w-3xl space-y-4">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <div key={index} className="h-5 animate-pulse rounded-full bg-muted/50" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (isError || !post) {
+    return (
+      <div className="mx-auto max-w-2xl space-y-6 text-center">
+        <h1 className="text-3xl font-semibold">Gönderi yüklenemedi</h1>
+        <p className="text-muted-foreground">
+          Şu anda gönderiyi görüntüleyemiyoruz. Lütfen daha sonra tekrar deneyin.
+        </p>
+        <Button asChild>
+          <Link to="/">Ana sayfaya dön</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-12">
+      <Button variant="ghost" className="group h-auto px-0 text-sm" asChild>
+        <Link to="/" className="inline-flex items-center gap-2 text-muted-foreground transition-colors group-hover:text-primary">
+          <ArrowLeft className="h-4 w-4 transition-transform duration-300 group-hover:-translate-x-1" />
+          Ana sayfaya dön
+        </Link>
+      </Button>
+
+      <motion.section
+        className="relative overflow-hidden rounded-[2.75rem] border border-border/50 bg-gradient-to-br from-background via-background to-muted/40"
+        initial={{ opacity: 0, y: 16 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+      >
+        {post.thumbnail && (
+          <img
+            src={post.thumbnail}
+            alt={post.title}
+            className="absolute inset-0 h-full w-full object-cover opacity-40"
+          />
+        )}
+        <div className="absolute inset-0 bg-gradient-to-br from-background via-background/60 to-background" aria-hidden />
+        <div className="relative z-10 space-y-6 px-6 py-14 text-center sm:px-10 lg:px-16">
+          <Badge className="mx-auto w-fit rounded-full bg-primary/80 px-4 py-1 text-xs uppercase tracking-wider text-primary-foreground">
+            {post.categoryName}
+          </Badge>
+          <h1 className="text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">{post.title}</h1>
+          <p className="mx-auto max-w-2xl text-lg text-muted-foreground">{post.summary}</p>
+        </div>
+      </motion.section>
+
+      <motion.section
+        className="mx-auto max-w-3xl space-y-8 rounded-3xl border border-border/60 bg-background/90 p-8 shadow-sm"
+        initial={{ opacity: 0, y: 24 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.1, duration: 0.4 }}
+      >
+        {contentBlocks.length > 0 ? (
+          contentBlocks.map((paragraph, index) => (
+            <p key={index} className="text-lg leading-relaxed text-muted-foreground">
+              {paragraph}
+            </p>
+          ))
+        ) : (
+          <p className="text-lg leading-relaxed text-muted-foreground">
+            {post.body}
+          </p>
+        )}
+      </motion.section>
+    </div>
+  );
+}

--- a/clients/blogapp-client/src/routes/router.tsx
+++ b/clients/blogapp-client/src/routes/router.tsx
@@ -2,6 +2,7 @@ import { Navigate, createBrowserRouter } from 'react-router-dom';
 import { PublicLayout } from '../components/layout/public-layout';
 import { HomePage } from '../pages/public/home-page';
 import { LoginPage } from '../pages/public/login-page';
+import { PostDetailPage } from '../pages/public/post-detail-page';
 import { ProtectedRoute } from './protected-route';
 import { AdminLayout } from '../components/layout/admin-layout';
 import { DashboardPage } from '../pages/admin/dashboard-page';
@@ -21,6 +22,10 @@ export const router = createBrowserRouter([
       {
         path: 'login',
         element: <LoginPage />
+      },
+      {
+        path: 'posts/:postId',
+        element: <PostDetailPage />
       }
     ]
   },

--- a/src/BlogApp.API/Controllers/PostController.cs
+++ b/src/BlogApp.API/Controllers/PostController.cs
@@ -4,6 +4,7 @@ using BlogApp.Application.Features.Posts.Commands.Delete;
 using BlogApp.Application.Features.Posts.Commands.Update;
 using BlogApp.Application.Features.Posts.Queries.GetById;
 using BlogApp.Application.Features.Posts.Queries.GetList;
+using BlogApp.Application.Features.Posts.Queries.GetListByCategoryId;
 using BlogApp.Application.Features.Posts.Queries.GetPaginatedListByDynamic;
 using BlogApp.Domain.Common.Requests;
 using BlogApp.Domain.Common.Responses;
@@ -19,7 +20,24 @@ namespace BlogApp.API.Controllers
         [HttpGet("GetList")]
         public async Task<IActionResult> GetList([FromQuery] PaginatedRequest pageRequest)
         {
-            PaginatedListResponse<GetListPostResponse> response = await Mediator.Send(new GetListPostQuery(pageRequest));
+            pageRequest ??= new PaginatedRequest();
+
+            PaginatedListResponse<GetListPostResponse> response = await Mediator.Send(
+                new GetListPostQuery(pageRequest)
+            );
+            return Ok(response);
+        }
+
+        [AllowAnonymous]
+        [HttpGet("GetListByCategoryId")]
+        public async Task<IActionResult> GetListByCategoryId([FromQuery] PaginatedRequest pageRequest, [FromQuery] int categoryId)
+        {
+            pageRequest ??= new PaginatedRequest();
+
+            PaginatedListResponse<GetListPostByCategoryIdResponse> response = await Mediator.Send(
+                new GetListPostByCategoryIdQuery(pageRequest, categoryId)
+            );
+
             return Ok(response);
         }
 

--- a/src/BlogApp.Application/Features/Posts/Profiles/PostProfile.cs
+++ b/src/BlogApp.Application/Features/Posts/Profiles/PostProfile.cs
@@ -1,10 +1,10 @@
-
 using AutoMapper;
 using BlogApp.Application.Features.Posts.Commands.Create;
 using BlogApp.Application.Features.Posts.Commands.Delete;
 using BlogApp.Application.Features.Posts.Commands.Update;
 using BlogApp.Application.Features.Posts.Queries.GetById;
 using BlogApp.Application.Features.Posts.Queries.GetList;
+using BlogApp.Application.Features.Posts.Queries.GetListByCategoryId;
 using BlogApp.Application.Features.Posts.Queries.GetPaginatedListByDynamic;
 using BlogApp.Domain.Common.Paging;
 using BlogApp.Domain.Common.Responses;
@@ -25,12 +25,15 @@ public sealed class PostProfile : Profile
         CreateMap<Post, GetListPostResponse>()
             .ForMember(dest => dest.CategoryName, opt => opt.MapFrom(src => src.Category != null ? src.Category.Name : string.Empty));
 
+        CreateMap<Post, GetListPostByCategoryIdResponse>()
+            .ForMember(dest => dest.CategoryName, opt => opt.MapFrom(src => src.Category != null ? src.Category.Name : string.Empty));
+
         CreateMap<Post, GetByIdPostResponse>()
             .ForMember(dest => dest.CategoryName, opt => opt.MapFrom(src => src.Category != null ? src.Category.Name : string.Empty))
             .ReverseMap();
 
         CreateMap<Paginate<Post>, PaginatedListResponse<GetPaginatedListByDynamicPostsResponse>>().ReverseMap();
         CreateMap<Paginate<Post>, PaginatedListResponse<GetListPostResponse>>().ReverseMap();
-
+        CreateMap<Paginate<Post>, PaginatedListResponse<GetListPostByCategoryIdResponse>>().ReverseMap();
     }
 }

--- a/src/BlogApp.Application/Features/Posts/Queries/GetList/GetListPostQuery.cs
+++ b/src/BlogApp.Application/Features/Posts/Queries/GetList/GetListPostQuery.cs
@@ -1,7 +1,8 @@
-﻿using BlogApp.Domain.Common.Requests;
+using BlogApp.Domain.Common.Requests;
 using BlogApp.Domain.Common.Responses;
 using MediatR;
 
 namespace BlogApp.Application.Features.Posts.Queries.GetList;
 
-public sealed record GetListPostQuery(PaginatedRequest PageRequest) : IRequest<PaginatedListResponse<GetListPostResponse>>;
+public sealed record GetListPostQuery(PaginatedRequest PageRequest)
+    : IRequest<PaginatedListResponse<GetListPostResponse>>;

--- a/src/BlogApp.Application/Features/Posts/Queries/GetListByCategoryId/GetListPostByCategoryIdQuery.cs
+++ b/src/BlogApp.Application/Features/Posts/Queries/GetListByCategoryId/GetListPostByCategoryIdQuery.cs
@@ -1,0 +1,8 @@
+using BlogApp.Domain.Common.Requests;
+using BlogApp.Domain.Common.Responses;
+using MediatR;
+
+namespace BlogApp.Application.Features.Posts.Queries.GetListByCategoryId;
+
+public sealed record GetListPostByCategoryIdQuery(PaginatedRequest PageRequest, int CategoryId)
+    : IRequest<PaginatedListResponse<GetListPostByCategoryIdResponse>>;

--- a/src/BlogApp.Application/Features/Posts/Queries/GetListByCategoryId/GetListPostByCategoryIdQueryHandler.cs
+++ b/src/BlogApp.Application/Features/Posts/Queries/GetListByCategoryId/GetListPostByCategoryIdQueryHandler.cs
@@ -1,0 +1,34 @@
+using System.Linq;
+using AutoMapper;
+using BlogApp.Domain.Common.Paging;
+using BlogApp.Domain.Common.Responses;
+using BlogApp.Domain.Entities;
+using BlogApp.Domain.Repositories;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace BlogApp.Application.Features.Posts.Queries.GetListByCategoryId;
+
+public sealed class GetListPostByCategoryIdQueryHandler(IPostRepository postRepository, IMapper mapper)
+    : IRequestHandler<GetListPostByCategoryIdQuery, PaginatedListResponse<GetListPostByCategoryIdResponse>>
+{
+    public async Task<PaginatedListResponse<GetListPostByCategoryIdResponse>> Handle(
+        GetListPostByCategoryIdQuery request,
+        CancellationToken cancellationToken
+    )
+    {
+        Paginate<Post> posts = await postRepository.GetPaginatedListAsync(
+            predicate: post => post.IsPublished && post.CategoryId == request.CategoryId,
+            orderBy: query => query.OrderByDescending(post => post.Id),
+            include: p => p.Include(p => p.Category),
+            index: request.PageRequest.PageIndex,
+            size: request.PageRequest.PageSize,
+            cancellationToken: cancellationToken
+        );
+
+        PaginatedListResponse<GetListPostByCategoryIdResponse> response =
+            mapper.Map<PaginatedListResponse<GetListPostByCategoryIdResponse>>(posts);
+
+        return response;
+    }
+}

--- a/src/BlogApp.Application/Features/Posts/Queries/GetListByCategoryId/GetListPostByCategoryIdResponse.cs
+++ b/src/BlogApp.Application/Features/Posts/Queries/GetListByCategoryId/GetListPostByCategoryIdResponse.cs
@@ -1,0 +1,12 @@
+namespace BlogApp.Application.Features.Posts.Queries.GetListByCategoryId;
+
+public sealed record GetListPostByCategoryIdResponse(
+    int Id,
+    string Title,
+    string Body,
+    string Summary,
+    string Thumbnail,
+    bool IsPublished,
+    string CategoryName,
+    int CategoryId
+);


### PR DESCRIPTION
## Summary
- add dedicated GetListPostByCategoryId query, handler, and response with a controller endpoint
- restore the generic post list query and extend the post profile mappings for the new response type
- update the client fetch helper to call the new category endpoint when filtering posts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fba4bf68388320b53e20e0de891b11