### PR TITLE
Improve blog post detail layout and HTML rendering

### DIFF
--- a/clients/blogapp-client/src/index.css
+++ b/clients/blogapp-client/src/index.css
@@ -54,3 +54,112 @@ body {
 html, body, #root {
   height: 100%;
 }
+
+@layer components {
+  .blog-content {
+    @apply mx-auto max-w-3xl text-balance text-lg leading-relaxed text-muted-foreground;
+  }
+
+  .blog-content > * + * {
+    @apply mt-6;
+  }
+
+  .blog-content h1,
+  .blog-content h2,
+  .blog-content h3,
+  .blog-content h4,
+  .blog-content h5,
+  .blog-content h6 {
+    @apply font-semibold tracking-tight text-foreground;
+  }
+
+  .blog-content h1 {
+    @apply text-4xl sm:text-5xl;
+  }
+
+  .blog-content h2 {
+    @apply mt-12 text-3xl sm:text-4xl;
+  }
+
+  .blog-content h3 {
+    @apply mt-10 text-2xl sm:text-3xl;
+  }
+
+  .blog-content h4 {
+    @apply mt-8 text-xl sm:text-2xl;
+  }
+
+  .blog-content p {
+    @apply text-lg leading-[1.8] text-muted-foreground/95;
+  }
+
+  .blog-content strong {
+    @apply text-foreground;
+  }
+
+  .blog-content a {
+    @apply text-primary underline decoration-2 underline-offset-4 transition-colors hover:text-primary/80;
+  }
+
+  .blog-content blockquote {
+    @apply border-l-4 border-primary/40 bg-primary/5 py-5 pl-6 pr-4 italic text-foreground;
+  }
+
+  .blog-content ul,
+  .blog-content ol {
+    @apply ml-6 space-y-3 text-lg leading-relaxed;
+  }
+
+  .blog-content ul {
+    @apply list-disc;
+  }
+
+  .blog-content ol {
+    @apply list-decimal;
+  }
+
+  .blog-content li {
+    @apply leading-relaxed;
+  }
+
+  .blog-content img,
+  .blog-content video {
+    @apply w-full rounded-3xl object-cover shadow-sm;
+  }
+
+  .blog-content figure {
+    @apply space-y-3;
+  }
+
+  .blog-content figcaption {
+    @apply text-sm text-muted-foreground/80;
+  }
+
+  .blog-content pre {
+    @apply overflow-x-auto rounded-2xl bg-muted/50 p-6 text-sm leading-relaxed text-foreground shadow-inner;
+  }
+
+  .blog-content code {
+    @apply rounded-md bg-muted/60 px-1.5 py-0.5 text-sm font-medium text-foreground;
+  }
+
+  .blog-content pre code {
+    @apply bg-transparent p-0 text-inherit;
+  }
+
+  .blog-content hr {
+    @apply my-12 border-border/70;
+  }
+
+  .blog-content table {
+    @apply w-full table-auto border-collapse text-left text-base;
+  }
+
+  .blog-content th {
+    @apply border-b border-border/80 py-3 font-semibold text-foreground;
+  }
+
+  .blog-content td {
+    @apply border-b border-border/60 py-3 text-muted-foreground;
+  }
+}

--- a/clients/blogapp-client/src/lib/sanitize-html.ts
+++ b/clients/blogapp-client/src/lib/sanitize-html.ts
@@ -1,0 +1,55 @@
+export function sanitizeHtml(html: string): string {
+  if (!html) {
+    return '';
+  }
+
+  if (typeof window === 'undefined') {
+    return html;
+  }
+
+  const parser = new window.DOMParser();
+  const documentFragment = parser.parseFromString(html, 'text/html');
+  const { body } = documentFragment;
+
+  if (!body) {
+    return '';
+  }
+
+  const blockedTags = ['script', 'style', 'iframe', 'object', 'embed', 'link', 'meta'];
+  blockedTags.forEach((tag) => {
+    body.querySelectorAll(tag).forEach((element) => element.remove());
+  });
+
+  const walker = documentFragment.createTreeWalker(body, NodeFilter.SHOW_ELEMENT);
+  const attributeProtocols = ['href', 'src', 'xlink:href'];
+
+  const isUnsafeProtocol = (value: string) => {
+    const normalised = value.trim().toLowerCase();
+    return normalised.startsWith('javascript:') || normalised.startsWith('vbscript:') || normalised.startsWith('data:');
+  };
+
+  while (walker.nextNode()) {
+    const element = walker.currentNode as HTMLElement;
+    const attributes = Array.from(element.attributes);
+
+    attributes.forEach((attribute) => {
+      const name = attribute.name.toLowerCase();
+
+      if (name.startsWith('on')) {
+        element.removeAttribute(attribute.name);
+        return;
+      }
+
+      if (name === 'style') {
+        element.removeAttribute(attribute.name);
+        return;
+      }
+
+      if (attributeProtocols.includes(name) && isUnsafeProtocol(attribute.value)) {
+        element.removeAttribute(attribute.name);
+      }
+    });
+  }
+
+  return body.innerHTML;
+}

--- a/clients/blogapp-client/src/pages/public/post-detail-page.tsx
+++ b/clients/blogapp-client/src/pages/public/post-detail-page.tsx
@@ -6,6 +6,7 @@ import { ArrowLeft } from 'lucide-react';
 import { getPostById } from '../../features/posts/api';
 import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
+import { sanitizeHtml } from '../../lib/sanitize-html';
 
 export function PostDetailPage() {
   const { postId } = useParams();
@@ -22,15 +23,12 @@ export function PostDetailPage() {
     enabled: isValidId
   });
 
-  const contentBlocks = useMemo(() => {
+  const sanitizedContent = useMemo(() => {
     if (!post?.body) {
-      return [];
+      return '';
     }
 
-    return post.body
-      .split(/\n{2,}/)
-      .map((paragraph) => paragraph.trim())
-      .filter(Boolean);
+    return sanitizeHtml(post.body);
   }, [post?.body]);
 
   if (!isValidId) {
@@ -107,22 +105,20 @@ export function PostDetailPage() {
       </motion.section>
 
       <motion.section
-        className="mx-auto max-w-3xl space-y-8 rounded-3xl border border-border/60 bg-background/90 p-8 shadow-sm"
+        className="mx-auto w-full max-w-4xl overflow-hidden rounded-[2.5rem] border border-border/70 bg-card/95 shadow-lg backdrop-blur"
         initial={{ opacity: 0, y: 24 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ delay: 0.1, duration: 0.4 }}
       >
-        {contentBlocks.length > 0 ? (
-          contentBlocks.map((paragraph, index) => (
-            <p key={index} className="text-lg leading-relaxed text-muted-foreground">
-              {paragraph}
-            </p>
-          ))
-        ) : (
-          <p className="text-lg leading-relaxed text-muted-foreground">
-            {post.body}
-          </p>
-        )}
+        <div className="bg-gradient-to-b from-background/80 via-background to-background/95 px-6 py-10 sm:px-10 sm:py-12 lg:px-16 lg:py-16">
+          {sanitizedContent ? (
+            <article className="blog-content" dangerouslySetInnerHTML={{ __html: sanitizedContent }} />
+          ) : (
+            <article className="blog-content">
+              <p>{post.summary ?? 'Bu gönderi için içerik bulunamadı.'}</p>
+            </article>
+          )}
+        </div>
       </motion.section>
     </div>
   );


### PR DESCRIPTION
## Summary
- render post bodies as sanitized HTML and present them in a comfortable reading layout
- add a lightweight browser-side sanitizer to strip unsafe tags and attributes from content
- introduce tailored typography styles so long-form elements like quotes, tables, and media remain readable

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fbb7b943c0832083a7790ba8ade06a