### PR TITLE
Polish post detail page layout and add ESLint config

### DIFF
--- a/clients/blogapp-client/.eslintrc.cjs
+++ b/clients/blogapp-client/.eslintrc.cjs
@@ -1,0 +1,22 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2022: true
+  },
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:react-hooks/recommended', 'prettier'],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true
+    }
+  },
+  plugins: ['@typescript-eslint', 'react-hooks', 'react-refresh'],
+  rules: {
+    '@typescript-eslint/no-explicit-any': 'off',
+    'react-refresh/only-export-components': 'off'
+  },
+  ignorePatterns: ['dist', 'build', 'coverage']
+};

--- a/clients/blogapp-client/src/index.css
+++ b/clients/blogapp-client/src/index.css
@@ -57,7 +57,7 @@ html, body, #root {
 
 @layer components {
   .blog-content {
-    @apply mx-auto max-w-3xl text-balance text-lg leading-relaxed text-muted-foreground;
+    @apply mx-auto max-w-4xl text-balance text-xl leading-relaxed text-muted-foreground;
   }
 
   .blog-content > * + * {
@@ -90,7 +90,7 @@ html, body, #root {
   }
 
   .blog-content p {
-    @apply text-lg leading-[1.8] text-muted-foreground/95;
+    @apply text-xl leading-[1.85] text-muted-foreground/90;
   }
 
   .blog-content strong {
@@ -107,7 +107,7 @@ html, body, #root {
 
   .blog-content ul,
   .blog-content ol {
-    @apply ml-6 space-y-3 text-lg leading-relaxed;
+    @apply ml-6 space-y-3 text-xl leading-relaxed;
   }
 
   .blog-content ul {

--- a/clients/blogapp-client/src/pages/public/post-detail-page.tsx
+++ b/clients/blogapp-client/src/pages/public/post-detail-page.tsx
@@ -2,8 +2,8 @@ import { useMemo } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { motion } from 'framer-motion';
-import { ArrowLeft } from 'lucide-react';
-import { getPostById } from '../../features/posts/api';
+import { ArrowLeft, ArrowRight, Calendar, Clock } from 'lucide-react';
+import { fetchPublishedPosts, getPostById } from '../../features/posts/api';
 import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
 import { sanitizeHtml } from '../../lib/sanitize-html';
@@ -65,6 +65,54 @@ export function PostDetailPage() {
     return sanitizeHtml(content);
   }, [post?.body]);
 
+  const { data: publishedPosts } = useQuery({
+    queryKey: ['posts', 'published', 'all'],
+    queryFn: () =>
+      fetchPublishedPosts({
+        pageIndex: 0,
+        pageSize: 200
+      }),
+    enabled: !!post
+  });
+
+  const { previousPost, nextPost } = useMemo(() => {
+    if (!post || !publishedPosts?.items?.length) {
+      return { previousPost: undefined, nextPost: undefined };
+    }
+
+    const currentIndex = publishedPosts.items.findIndex((item) => item.id === post.id);
+
+    if (currentIndex === -1) {
+      return { previousPost: undefined, nextPost: undefined };
+    }
+
+    const previous = currentIndex < publishedPosts.items.length - 1 ? publishedPosts.items[currentIndex + 1] : undefined;
+    const next = currentIndex > 0 ? publishedPosts.items[currentIndex - 1] : undefined;
+
+    return { previousPost: previous, nextPost: next };
+  }, [post, publishedPosts?.items]);
+
+  const readingInsights = useMemo(() => {
+    if (!post?.body) {
+      return { wordCount: 0, readingMinutes: 0 };
+    }
+
+    const text = post.body
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/&nbsp;/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+
+    if (!text) {
+      return { wordCount: 0, readingMinutes: 0 };
+    }
+
+    const words = text.split(' ').filter(Boolean);
+    const readingMinutes = Math.max(1, Math.round(words.length / 200));
+
+    return { wordCount: words.length, readingMinutes };
+  }, [post?.body]);
+
   if (!isValidId) {
     return (
       <div className="mx-auto max-w-2xl space-y-6 text-center">
@@ -106,54 +154,230 @@ export function PostDetailPage() {
     );
   }
 
+  const categoryLabel = post.categoryName?.trim() || 'Kategori belirtilmemiş';
+  const previousPostUrl = previousPost ? `/posts/${previousPost.id}` : '';
+  const nextPostUrl = nextPost ? `/posts/${nextPost.id}` : '';
+
   return (
-    <div className="space-y-12">
-      <Button variant="ghost" className="group h-auto px-0 text-sm" asChild>
-        <Link to="/" className="inline-flex items-center gap-2 text-muted-foreground transition-colors group-hover:text-primary">
-          <ArrowLeft className="h-4 w-4 transition-transform duration-300 group-hover:-translate-x-1" />
-          Ana sayfaya dön
-        </Link>
-      </Button>
+    <div className="relative isolate pb-24">
+      <div
+        className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-primary/10 via-background to-secondary/20"
+        aria-hidden
+      />
+      <div
+        className="pointer-events-none absolute -left-24 top-24 -z-10 h-72 w-72 rounded-full bg-primary/15 blur-3xl sm:h-96 sm:w-96"
+        aria-hidden
+      />
+      <div
+        className="pointer-events-none absolute -right-20 top-1/2 -z-10 h-80 w-80 rounded-full bg-secondary/25 blur-3xl sm:h-[28rem] sm:w-[28rem]"
+        aria-hidden
+      />
 
-      <motion.section
-        className="relative overflow-hidden rounded-[2.75rem] border border-border/50 bg-gradient-to-br from-background via-background to-muted/40"
-        initial={{ opacity: 0, y: 16 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.4 }}
-      >
-        {post.thumbnail && (
-          <img
-            src={post.thumbnail}
-            alt={post.title}
-            className="absolute inset-0 h-full w-full object-cover opacity-40"
-          />
-        )}
-        <div className="absolute inset-0 bg-gradient-to-br from-background via-background/60 to-background" aria-hidden />
-        <div className="relative z-10 space-y-6 px-6 py-14 text-center sm:px-10 lg:px-16">
-          <Badge className="mx-auto w-fit rounded-full bg-primary/80 px-4 py-1 text-xs uppercase tracking-wider text-primary-foreground">
-            {post.categoryName}
-          </Badge>
-          <h1 className="text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">{post.title}</h1>
-          <p className="mx-auto max-w-2xl text-lg text-muted-foreground">{post.summary}</p>
-        </div>
-      </motion.section>
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-16 px-4 sm:px-6 lg:px-8">
+        <Button variant="ghost" className="group mt-4 h-auto w-fit px-0 text-sm" asChild>
+          <Link to="/" className="inline-flex items-center gap-2 text-muted-foreground transition-colors group-hover:text-primary">
+            <ArrowLeft className="h-4 w-4 transition-transform duration-300 group-hover:-translate-x-1" />
+            Ana sayfaya dön
+          </Link>
+        </Button>
 
-      <motion.section
-        className="mx-auto w-full max-w-4xl overflow-hidden rounded-[2.5rem] border border-border/70 bg-card/95 shadow-lg backdrop-blur"
-        initial={{ opacity: 0, y: 24 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ delay: 0.1, duration: 0.4 }}
-      >
-        <div className="bg-gradient-to-b from-background/80 via-background to-background/95 px-6 py-10 sm:px-10 sm:py-12 lg:px-16 lg:py-16">
-          {sanitizedContent ? (
-            <article className="blog-content" dangerouslySetInnerHTML={{ __html: sanitizedContent }} />
-          ) : (
-            <article className="blog-content">
-              <p>{post.summary ?? 'Bu gönderi için içerik bulunamadı.'}</p>
-            </article>
-          )}
-        </div>
-      </motion.section>
+        <motion.section
+          className="relative overflow-hidden rounded-[3rem] border border-border/40 bg-gradient-to-br from-primary/10 via-background to-secondary/20 shadow-xl shadow-primary/10"
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4 }}
+        >
+          <div className="grid gap-12 px-6 py-14 sm:px-12 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)] lg:items-center lg:px-20">
+            <div className="relative z-10 space-y-7 text-center lg:text-left">
+              <Badge className="mx-auto w-fit rounded-full bg-primary/80 px-4 py-1 text-xs uppercase tracking-wider text-primary-foreground shadow-sm lg:mx-0">
+                {categoryLabel}
+              </Badge>
+              <h1 className="mx-auto max-w-3xl text-balance text-4xl font-semibold tracking-tight text-foreground sm:text-5xl lg:mx-0 lg:text-6xl">
+                {post.title}
+              </h1>
+              <p className="mx-auto max-w-2xl text-lg text-muted-foreground/90 sm:text-xl lg:mx-0">{post.summary}</p>
+              <div className="flex flex-wrap items-center justify-center gap-3 text-sm text-muted-foreground/80 lg:justify-start">
+                <span className="inline-flex items-center gap-2 rounded-full bg-background/60 px-4 py-2 shadow-sm ring-1 ring-border/60">
+                  <Calendar className="h-4 w-4" />
+                  Yayınlanan makale
+                </span>
+                {readingInsights.wordCount > 0 && (
+                  <span className="inline-flex items-center gap-2 rounded-full bg-background/60 px-4 py-2 shadow-sm ring-1 ring-border/60">
+                    <Clock className="h-4 w-4" />
+                    {readingInsights.readingMinutes} dakikalık okuma · {readingInsights.wordCount} kelime
+                  </span>
+                )}
+              </div>
+            </div>
+
+            <div className="relative">
+              <div className="absolute inset-0 rounded-[3rem] bg-gradient-to-br from-primary/25 via-primary/10 to-secondary/30 opacity-70 blur-3xl" />
+              <div className="relative overflow-hidden rounded-[2.5rem] border border-border/50 bg-background/80 shadow-2xl shadow-primary/10">
+                {post.thumbnail ? (
+                  <img src={post.thumbnail} alt={post.title} className="h-full w-full object-cover" />
+                ) : (
+                  <div className="flex h-full min-h-[260px] items-center justify-center bg-gradient-to-br from-primary/10 via-primary/5 to-secondary/15 p-10 text-center text-lg text-muted-foreground">
+                    Bu makale için görsel henüz eklenmedi.
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </motion.section>
+
+        <motion.section
+          className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_320px]"
+          initial={{ opacity: 0, y: 24 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.1, duration: 0.4 }}
+        >
+          <div className="overflow-hidden rounded-[2.75rem] border border-border/70 bg-card/95 shadow-xl backdrop-blur">
+            <div className="bg-gradient-to-b from-background/95 via-background to-secondary/10 px-6 py-10 sm:px-12 sm:py-14 lg:px-16 lg:py-20">
+              <div className="mb-10 flex flex-wrap items-center justify-center gap-3 text-sm text-muted-foreground/80 sm:justify-between">
+                <Badge variant="secondary" className="rounded-full bg-secondary/80 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-secondary-foreground">
+                  {categoryLabel}
+                </Badge>
+                {readingInsights.wordCount > 0 && (
+                  <span className="inline-flex items-center gap-2 rounded-full bg-background/70 px-3 py-1.5 ring-1 ring-border/60">
+                    <Clock className="h-4 w-4" />
+                    {readingInsights.readingMinutes} dakika · {readingInsights.wordCount} kelime
+                  </span>
+                )}
+              </div>
+
+              {sanitizedContent ? (
+                <article className="blog-content" dangerouslySetInnerHTML={{ __html: sanitizedContent }} />
+              ) : (
+                <article className="blog-content">
+                  <p>{post.summary ?? 'Bu gönderi için içerik bulunamadı.'}</p>
+                </article>
+              )}
+            </div>
+          </div>
+
+          <aside className="flex flex-col gap-6 lg:pt-4">
+            <div className="sticky top-28 space-y-6">
+              <div className="overflow-hidden rounded-[2rem] border border-border/70 bg-gradient-to-br from-background to-secondary/20 p-8 shadow-lg">
+                <h2 className="text-xl font-semibold text-foreground">Makale bilgileri</h2>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Göz yormayan renkler ve ferah bir düzen ile bu yazıyı keyifle okuyabilirsiniz.
+                </p>
+                <div className="mt-6 space-y-4 text-sm text-muted-foreground">
+                  <div className="flex items-center justify-between rounded-xl bg-background/80 px-4 py-3 ring-1 ring-border/70">
+                    <span className="font-medium text-foreground">Kategori</span>
+                    <span className="truncate text-right text-foreground/90" title={categoryLabel}>
+                      {categoryLabel}
+                    </span>
+                  </div>
+                  {readingInsights.wordCount > 0 && (
+                    <div className="flex items-center justify-between rounded-xl bg-background/80 px-4 py-3 ring-1 ring-border/70">
+                      <span className="font-medium text-foreground">Okuma süresi</span>
+                      <span>{readingInsights.readingMinutes} dakika</span>
+                    </div>
+                  )}
+                  {readingInsights.wordCount > 0 && (
+                    <div className="flex items-center justify-between rounded-xl bg-background/80 px-4 py-3 ring-1 ring-border/70">
+                      <span className="font-medium text-foreground">Kelime sayısı</span>
+                      <span>{readingInsights.wordCount}</span>
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              <div className="rounded-[2rem] border border-border/70 bg-gradient-to-br from-primary/10 via-primary/5 to-secondary/25 p-8 shadow-lg">
+                <h3 className="text-lg font-semibold text-foreground">Yeni hikayeleri keşfet</h3>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Okumaya ara verdiğinizde bile sonraki veya önceki yazıya kolayca geçebilirsiniz.
+                </p>
+                <div className="mt-6 space-y-3 text-sm">
+                  {previousPost ? (
+                    <Link
+                      to={previousPostUrl}
+                      className="group flex items-center justify-between rounded-xl border border-border/60 bg-background/85 px-4 py-3 font-medium text-foreground transition hover:border-primary/60 hover:bg-primary/10"
+                    >
+                      <span>Önceki yazıya git</span>
+                      <ArrowLeft className="h-4 w-4 text-primary transition-transform duration-300 group-hover:-translate-x-1" />
+                    </Link>
+                  ) : (
+                    <div className="flex items-center justify-between rounded-xl border border-dashed border-border/60 bg-muted/30 px-4 py-3 text-muted-foreground">
+                      <span>Önceki yazı bulunamadı</span>
+                      <ArrowLeft className="h-4 w-4" />
+                    </div>
+                  )}
+
+                  {nextPost ? (
+                    <Link
+                      to={nextPostUrl}
+                      className="group flex items-center justify-between rounded-xl border border-border/60 bg-background/85 px-4 py-3 font-medium text-foreground transition hover:border-primary/60 hover:bg-primary/10"
+                    >
+                      <span>Sonraki yazıya git</span>
+                      <ArrowRight className="h-4 w-4 text-primary transition-transform duration-300 group-hover:translate-x-1" />
+                    </Link>
+                  ) : (
+                    <div className="flex items-center justify-between rounded-xl border border-dashed border-border/60 bg-muted/30 px-4 py-3 text-muted-foreground">
+                      <span>Sonraki yazı bulunamadı</span>
+                      <ArrowRight className="h-4 w-4" />
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          </aside>
+        </motion.section>
+
+        <motion.nav
+          className="rounded-[2.75rem] border border-border/50 bg-background/95 p-6 shadow-2xl shadow-primary/10 backdrop-blur"
+          initial={{ opacity: 0, y: 24 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.2, duration: 0.4 }}
+        >
+          <div className="grid gap-4 lg:grid-cols-2">
+            {previousPost ? (
+              <Link
+                to={previousPostUrl}
+                className="group flex h-full flex-col justify-between rounded-3xl border border-border/60 bg-background/95 p-6 text-left shadow-lg transition hover:-translate-y-1 hover:border-primary/60 hover:bg-primary/10"
+              >
+                <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground group-hover:text-primary">
+                  Bir önceki yazı
+                </span>
+                <span className="text-lg font-semibold text-balance text-foreground group-hover:text-primary/90">
+                  {previousPost.title}
+                </span>
+                <span className="mt-3 inline-flex items-center gap-2 text-sm font-medium text-primary/80 group-hover:text-primary">
+                  <ArrowLeft className="h-4 w-4 transition-transform duration-300 group-hover:-translate-x-1" />
+                  Önceki gönderiye git
+                </span>
+              </Link>
+            ) : (
+              <div className="flex h-full flex-col justify-center rounded-3xl border border-dashed border-border/60 bg-muted/30 p-6 text-sm text-muted-foreground">
+                Daha eski bir yazı bulunamadı.
+              </div>
+            )}
+
+            {nextPost ? (
+              <Link
+                to={nextPostUrl}
+                className="group flex h-full flex-col justify-between rounded-3xl border border-border/60 bg-background/95 p-6 text-left shadow-lg transition hover:-translate-y-1 hover:border-primary/60 hover:bg-primary/10"
+              >
+                <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground group-hover:text-primary">
+                  Bir sonraki yazı
+                </span>
+                <span className="text-lg font-semibold text-balance text-foreground group-hover:text-primary/90">
+                  {nextPost.title}
+                </span>
+                <span className="mt-3 inline-flex items-center gap-2 text-sm font-medium text-primary/80 group-hover:text-primary">
+                  Sonraki gönderiye git
+                  <ArrowRight className="h-4 w-4 transition-transform duration-300 group-hover:translate-x-1" />
+                </span>
+              </Link>
+            ) : (
+              <div className="flex h-full flex-col justify-center rounded-3xl border border-dashed border-border/60 bg-muted/30 p-6 text-sm text-muted-foreground">
+                Daha yeni bir yazı bulunamadı.
+              </div>
+            )}
+          </div>
+        </motion.nav>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- reorganize the post detail layout to use a centered container, pastel gradients, and clearer spacing for copy and media
- surface category and reading insights in both the article body and sidebar while wiring "Yeni hikayeleri keşfet" links to real previous/next posts
- add a project-local ESLint configuration so npm run lint runs with consistent TypeScript and refresh rules

## Testing
- npm run lint *(warns: unsupported TypeScript version notice from @typescript-eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68fbbcec7cbc8320b0d430e0e8503a71