### PR TITLE
Add scroll reset and floating scroll-to-top control

### DIFF
--- a/clients/blogapp-client/src/components/layout/admin-layout.tsx
+++ b/clients/blogapp-client/src/components/layout/admin-layout.tsx
@@ -1,11 +1,17 @@
-import { useState } from 'react';
-import { Outlet } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { Outlet, useLocation } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { AdminSidebar } from '../admin/sidebar';
 import { AdminHeader } from '../admin/admin-header';
+import { ScrollToTopButton } from '../ui/scroll-to-top-button';
 
 export function AdminLayout() {
   const [collapsed, setCollapsed] = useState(false);
+  const location = useLocation();
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'auto' });
+  }, [location.pathname, location.search]);
 
   return (
     <div className="flex min-h-screen bg-muted/30">
@@ -24,6 +30,7 @@ export function AdminLayout() {
           <Outlet />
         </motion.main>
       </div>
+      <ScrollToTopButton />
     </div>
   );
 }

--- a/clients/blogapp-client/src/components/layout/public-layout.tsx
+++ b/clients/blogapp-client/src/components/layout/public-layout.tsx
@@ -1,9 +1,17 @@
-import { Outlet } from 'react-router-dom';
+import { useEffect } from 'react';
+import { Outlet, useLocation } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { Navbar } from '../navigation/navbar';
 import { Footer } from './footer';
+import { ScrollToTopButton } from '../ui/scroll-to-top-button';
 
 export function PublicLayout() {
+  const location = useLocation();
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'auto' });
+  }, [location.pathname, location.search]);
+
   return (
     <div className="flex min-h-screen flex-col">
       <Navbar />
@@ -18,6 +26,7 @@ export function PublicLayout() {
         </motion.div>
       </main>
       <Footer />
+      <ScrollToTopButton />
     </div>
   );
 }

--- a/clients/blogapp-client/src/components/ui/scroll-to-top-button.tsx
+++ b/clients/blogapp-client/src/components/ui/scroll-to-top-button.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+import { ArrowUp } from 'lucide-react';
+
+import { Button } from './button';
+import { cn } from '../../lib/utils';
+
+export function ScrollToTopButton() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setIsVisible(window.scrollY > 200);
+    };
+
+    handleScroll();
+    window.addEventListener('scroll', handleScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  return (
+    <div className="pointer-events-none fixed bottom-6 right-6 z-50">
+      <Button
+        type="button"
+        size="icon"
+        variant="secondary"
+        aria-label="Yukarı çık"
+        onClick={scrollToTop}
+        className={cn(
+          'pointer-events-auto rounded-full shadow-lg transition-all duration-200',
+          isVisible
+            ? 'translate-y-0 opacity-100'
+            : 'translate-y-4 opacity-0'
+        )}
+      >
+        <ArrowUp className="h-5 w-5" />
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable floating scroll-to-top button component
- integrate the button into public and admin layouts and reset scroll position on navigation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fbc80210f483209466645113009009