### PR TITLE
Allow anonymous access to post details

### DIFF
--- a/src/BlogApp.API/Controllers/PostController.cs
+++ b/src/BlogApp.API/Controllers/PostController.cs
@@ -48,6 +48,7 @@ namespace BlogApp.API.Controllers
             return Ok(response);
         }
 
+        [AllowAnonymous]
         [HttpGet("GetById/{id}")]
         public async Task<IActionResult> GetById([FromRoute] int id)
         {

--- a/src/BlogApp.API/Controllers/PostController.cs
+++ b/src/BlogApp.API/Controllers/PostController.cs
@@ -52,7 +52,8 @@ namespace BlogApp.API.Controllers
         [HttpGet("GetById/{id}")]
         public async Task<IActionResult> GetById([FromRoute] int id)
         {
-            var response = await Mediator.Send(new GetByIdPostQuery(id));
+            bool includeUnpublished = User.Identity?.IsAuthenticated == true;
+            var response = await Mediator.Send(new GetByIdPostQuery(id, includeUnpublished));
             return Ok(response);
         }
 

--- a/src/BlogApp.Application/Features/Posts/Queries/GetById/GetByIdPostQuery.cs
+++ b/src/BlogApp.Application/Features/Posts/Queries/GetById/GetByIdPostQuery.cs
@@ -3,4 +3,4 @@ using MediatR;
 
 namespace BlogApp.Application.Features.Posts.Queries.GetById;
 
-public sealed record GetByIdPostQuery(int Id) : IRequest<IDataResult<GetByIdPostResponse>>;
+public sealed record GetByIdPostQuery(int Id, bool IncludeUnpublished) : IRequest<IDataResult<GetByIdPostResponse>>;

--- a/src/BlogApp.Application/Features/Posts/Queries/GetById/GetPostByIdQueryHandler.cs
+++ b/src/BlogApp.Application/Features/Posts/Queries/GetById/GetPostByIdQueryHandler.cs
@@ -10,7 +10,10 @@ public sealed class GetPostByIdQueryHandler(IPostRepository postRepository, IMap
 {
     public async Task<IDataResult<GetByIdPostResponse>> Handle(GetByIdPostQuery request, CancellationToken cancellationToken)
     {
-        Post? post = await postRepository.GetAsync(predicate: b => b.Id == request.Id, cancellationToken: cancellationToken);
+        Post? post = await postRepository.GetAsync(
+            predicate: b => b.Id == request.Id && (request.IncludeUnpublished || b.IsPublished),
+            cancellationToken: cancellationToken
+        );
         if (post is null)
             return new ErrorDataResult<GetByIdPostResponse>("Post bilgisi bulunamadı.");
 


### PR DESCRIPTION
## Summary
- allow unauthenticated callers to access the post details endpoint

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fbc9ad23488320a9a66556a56b579c