### PR TITLE
Remove mediator dependency from command handlers

### DIFF
--- a/src/BlogApp.Application/Features/Permissions/Commands/AssignPermissionsToRole/AssignPermissionsToRoleCommandHandler.cs
+++ b/src/BlogApp.Application/Features/Permissions/Commands/AssignPermissionsToRole/AssignPermissionsToRoleCommandHandler.cs
@@ -13,20 +13,17 @@ public class AssignPermissionsToRoleCommandHandler : IRequestHandler<AssignPermi
 {
     private readonly IPermissionRepository _permissionRepository;
     private readonly IRoleRepository _roleRepository;
-    private readonly IMediator _mediator;
     private readonly ICurrentUserService _currentUserService;
     private readonly IUnitOfWork _unitOfWork;
 
     public AssignPermissionsToRoleCommandHandler(
         IPermissionRepository permissionRepository,
         IRoleRepository roleRepository,
-        IMediator mediator,
         ICurrentUserService currentUserService,
         IUnitOfWork unitOfWork)
     {
         _permissionRepository = permissionRepository;
         _roleRepository = roleRepository;
-        _mediator = mediator;
         _currentUserService = currentUserService;
         _unitOfWork = unitOfWork;
     }

--- a/src/BlogApp.Application/Features/Roles/Commands/Create/CreateRoleCommandHandler.cs
+++ b/src/BlogApp.Application/Features/Roles/Commands/Create/CreateRoleCommandHandler.cs
@@ -12,18 +12,15 @@ namespace BlogApp.Application.Features.Roles.Commands.Create;
 public sealed class CreateRoleCommandHandler : IRequestHandler<CreateRoleCommand, IResult>
 {
     private readonly IRoleRepository _roleRepository;
-    private readonly IMediator _mediator;
     private readonly ICurrentUserService _currentUserService;
     private readonly IUnitOfWork _unitOfWork;
 
     public CreateRoleCommandHandler(
         IRoleRepository roleRepository,
-        IMediator mediator,
         ICurrentUserService currentUserService,
         IUnitOfWork unitOfWork)
     {
         _roleRepository = roleRepository;
-        _mediator = mediator;
         _currentUserService = currentUserService;
         _unitOfWork = unitOfWork;
     }

--- a/src/BlogApp.Application/Features/Roles/Commands/Delete/DeleteRoleCommandHandler.cs
+++ b/src/BlogApp.Application/Features/Roles/Commands/Delete/DeleteRoleCommandHandler.cs
@@ -11,18 +11,15 @@ namespace BlogApp.Application.Features.Roles.Commands.Delete;
 public sealed class DeleteRoleCommandHandler : IRequestHandler<DeleteRoleCommand, IResult>
 {
     private readonly IRoleRepository _roleRepository;
-    private readonly IMediator _mediator;
     private readonly ICurrentUserService _currentUserService;
     private readonly IUnitOfWork _unitOfWork;
 
     public DeleteRoleCommandHandler(
         IRoleRepository roleRepository,
-        IMediator mediator,
         ICurrentUserService currentUserService,
         IUnitOfWork unitOfWork)
     {
         _roleRepository = roleRepository;
-        _mediator = mediator;
         _currentUserService = currentUserService;
         _unitOfWork = unitOfWork;
     }

--- a/src/BlogApp.Application/Features/Roles/Commands/Update/UpdateRoleCommandHandler.cs
+++ b/src/BlogApp.Application/Features/Roles/Commands/Update/UpdateRoleCommandHandler.cs
@@ -12,18 +12,15 @@ namespace BlogApp.Application.Features.Roles.Commands.Update;
 public sealed class UpdateRoleCommandHandler : IRequestHandler<UpdateRoleCommand, IResult>
 {
     private readonly IRoleRepository _roleRepository;
-    private readonly IMediator _mediator;
     private readonly ICurrentUserService _currentUserService;
     private readonly IUnitOfWork _unitOfWork;
 
     public UpdateRoleCommandHandler(
         IRoleRepository roleRepository,
-        IMediator mediator,
         ICurrentUserService currentUserService,
         IUnitOfWork unitOfWork)
     {
         _roleRepository = roleRepository;
-        _mediator = mediator;
         _currentUserService = currentUserService;
         _unitOfWork = unitOfWork;
     }

--- a/src/BlogApp.Application/Features/Users/Commands/AssignRolesToUser/AssignRolesToUserCommandHandler.cs
+++ b/src/BlogApp.Application/Features/Users/Commands/AssignRolesToUser/AssignRolesToUserCommandHandler.cs
@@ -14,20 +14,17 @@ public class AssignRolesToUserCommandHandler : IRequestHandler<AssignRolesToUser
 {
     private readonly IUserRepository _userRepository;
     private readonly IRoleRepository _roleRepository;
-    private readonly IMediator _mediator;
     private readonly ICurrentUserService _currentUserService;
     private readonly IUnitOfWork _unitOfWork;
 
     public AssignRolesToUserCommandHandler(
         IUserRepository userRepository,
         IRoleRepository roleRepository,
-        IMediator mediator,
         ICurrentUserService currentUserService,
         IUnitOfWork unitOfWork)
     {
         _userRepository = userRepository;
         _roleRepository = roleRepository;
-        _mediator = mediator;
         _currentUserService = currentUserService;
         _unitOfWork = unitOfWork;
     }

--- a/src/BlogApp.Application/Features/Users/Commands/Create/CreateUserCommandHandler.cs
+++ b/src/BlogApp.Application/Features/Users/Commands/Create/CreateUserCommandHandler.cs
@@ -14,18 +14,15 @@ namespace BlogApp.Application.Features.Users.Commands.Create;
 public sealed class CreateUserCommandHandler : IRequestHandler<CreateUserCommand, IResult>
 {
     private readonly IUserRepository _userRepository;
-    private readonly IMediator _mediator;
     private readonly ICurrentUserService _currentUserService;
     private readonly IUnitOfWork _unitOfWork;
 
     public CreateUserCommandHandler(
         IUserRepository userRepository,
-        IMediator mediator,
         ICurrentUserService currentUserService,
         IUnitOfWork unitOfWork)
     {
         _userRepository = userRepository;
-        _mediator = mediator;
         _currentUserService = currentUserService;
         _unitOfWork = unitOfWork;
     }

--- a/src/BlogApp.Application/Features/Users/Commands/Delete/DeleteUserCommandHandler.cs
+++ b/src/BlogApp.Application/Features/Users/Commands/Delete/DeleteUserCommandHandler.cs
@@ -11,18 +11,15 @@ namespace BlogApp.Application.Features.Users.Commands.Delete;
 public sealed class DeleteUserCommandHandler : IRequestHandler<DeleteUserCommand, IResult>
 {
     private readonly IUserRepository _userRepository;
-    private readonly IMediator _mediator;
     private readonly ICurrentUserService _currentUserService;
     private readonly IUnitOfWork _unitOfWork;
 
     public DeleteUserCommandHandler(
         IUserRepository userRepository,
-        IMediator mediator,
         ICurrentUserService currentUserService,
         IUnitOfWork unitOfWork)
     {
         _userRepository = userRepository;
-        _mediator = mediator;
         _currentUserService = currentUserService;
         _unitOfWork = unitOfWork;
     }

--- a/src/BlogApp.Application/Features/Users/Commands/Update/UpdateUserCommandHandler.cs
+++ b/src/BlogApp.Application/Features/Users/Commands/Update/UpdateUserCommandHandler.cs
@@ -12,18 +12,15 @@ namespace BlogApp.Application.Features.Users.Commands.Update;
 public sealed class UpdateUserCommandHandler : IRequestHandler<UpdateUserCommand, IResult>
 {
     private readonly IUserRepository _userRepository;
-    private readonly IMediator _mediator;
     private readonly ICurrentUserService _currentUserService;
     private readonly IUnitOfWork _unitOfWork;
 
     public UpdateUserCommandHandler(
         IUserRepository userRepository,
-        IMediator mediator,
         ICurrentUserService currentUserService,
         IUnitOfWork unitOfWork)
     {
         _userRepository = userRepository;
-        _mediator = mediator;
         _currentUserService = currentUserService;
         _unitOfWork = unitOfWork;
     }


### PR DESCRIPTION
## Summary
- remove the unused IMediator dependencies from role, permission, and user command handlers

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68fddded35908320b271497642faa8c2