### PR TITLE
Ensure outbox status updates persist per message

### DIFF
--- a/src/BlogApp.Infrastructure/InfrastructureServicesRegistration.cs
+++ b/src/BlogApp.Infrastructure/InfrastructureServicesRegistration.cs
@@ -7,6 +7,7 @@ using BlogApp.Infrastructure.Authorization;
 using BlogApp.Infrastructure.Consumers;
 using BlogApp.Infrastructure.Services;
 using BlogApp.Infrastructure.Services.Identity;
+using BlogApp.Infrastructure.Services.BackgroundServices.Outbox.Converters;
 using MassTransit;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
@@ -124,6 +125,21 @@ namespace BlogApp.Infrastructure
 
             // Background Services
             services.AddHostedService<Services.BackgroundServices.OutboxProcessorService>();
+
+            services.AddSingleton<IIntegrationEventConverterStrategy, CategoryCreatedIntegrationEventConverter>();
+            services.AddSingleton<IIntegrationEventConverterStrategy, CategoryUpdatedIntegrationEventConverter>();
+            services.AddSingleton<IIntegrationEventConverterStrategy, CategoryDeletedIntegrationEventConverter>();
+            services.AddSingleton<IIntegrationEventConverterStrategy, PostCreatedIntegrationEventConverter>();
+            services.AddSingleton<IIntegrationEventConverterStrategy, PostUpdatedIntegrationEventConverter>();
+            services.AddSingleton<IIntegrationEventConverterStrategy, PostDeletedIntegrationEventConverter>();
+            services.AddSingleton<IIntegrationEventConverterStrategy, UserCreatedIntegrationEventConverter>();
+            services.AddSingleton<IIntegrationEventConverterStrategy, UserUpdatedIntegrationEventConverter>();
+            services.AddSingleton<IIntegrationEventConverterStrategy, UserDeletedIntegrationEventConverter>();
+            services.AddSingleton<IIntegrationEventConverterStrategy, UserRolesAssignedIntegrationEventConverter>();
+            services.AddSingleton<IIntegrationEventConverterStrategy, RoleCreatedIntegrationEventConverter>();
+            services.AddSingleton<IIntegrationEventConverterStrategy, RoleUpdatedIntegrationEventConverter>();
+            services.AddSingleton<IIntegrationEventConverterStrategy, RoleDeletedIntegrationEventConverter>();
+            services.AddSingleton<IIntegrationEventConverterStrategy, PermissionsAssignedToRoleIntegrationEventConverter>();
 
             services.AddSingleton<ITelegramService, TelegramService>();
             services.AddSingleton<ICacheService, RedisCacheService>();

--- a/src/BlogApp.Infrastructure/Services/BackgroundServices/Outbox/Converters/ActivityLogIntegrationEventConverters.cs
+++ b/src/BlogApp.Infrastructure/Services/BackgroundServices/Outbox/Converters/ActivityLogIntegrationEventConverters.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Text.Json;
+using BlogApp.Domain.Events.CategoryEvents;
+using BlogApp.Domain.Events.IntegrationEvents;
+using BlogApp.Domain.Events.PermissionEvents;
+using BlogApp.Domain.Events.PostEvents;
+using BlogApp.Domain.Events.RoleEvents;
+using BlogApp.Domain.Events.UserEvents;
+
+namespace BlogApp.Infrastructure.Services.BackgroundServices.Outbox.Converters;
+
+public interface IIntegrationEventConverterStrategy
+{
+    string EventType { get; }
+    object? Convert(string payload);
+}
+
+internal abstract class ActivityLogIntegrationEventConverter<TDomainEvent> : IIntegrationEventConverterStrategy
+{
+    public abstract string EventType { get; }
+
+    public object? Convert(string payload)
+    {
+        var domainEvent = JsonSerializer.Deserialize<TDomainEvent>(payload);
+        return domainEvent is null
+            ? null
+            : Convert(domainEvent);
+    }
+
+    protected abstract ActivityLogCreatedIntegrationEvent Convert(TDomainEvent domainEvent);
+}
+
+internal sealed class CategoryCreatedIntegrationEventConverter : ActivityLogIntegrationEventConverter<CategoryCreatedEvent>
+{
+    public override string EventType => nameof(CategoryCreatedEvent);
+
+    protected override ActivityLogCreatedIntegrationEvent Convert(CategoryCreatedEvent domainEvent) => new(
+        ActivityType: "category_created",
+        EntityType: "Category",
+        EntityId: domainEvent.CategoryId,
+        Title: $"\"{domainEvent.Name}\" kategorisi oluşturuldu",
+        Details: null,
+        UserId: domainEvent.CreatedById,
+        Timestamp: DateTime.UtcNow
+    );
+}
+
+internal sealed class CategoryUpdatedIntegrationEventConverter : ActivityLogIntegrationEventConverter<CategoryUpdatedEvent>
+{
+    public override string EventType => nameof(CategoryUpdatedEvent);
+
+    protected override ActivityLogCreatedIntegrationEvent Convert(CategoryUpdatedEvent domainEvent) => new(
+        ActivityType: "category_updated",
+        EntityType: "Category",
+        EntityId: domainEvent.CategoryId,
+        Title: $"\"{domainEvent.Name}\" kategorisi güncellendi",
+        Details: null,
+        UserId: domainEvent.UpdatedById,
+        Timestamp: DateTime.UtcNow
+    );
+}
+
+internal sealed class CategoryDeletedIntegrationEventConverter : ActivityLogIntegrationEventConverter<CategoryDeletedEvent>
+{
+    public override string EventType => nameof(CategoryDeletedEvent);
+
+    protected override ActivityLogCreatedIntegrationEvent Convert(CategoryDeletedEvent domainEvent) => new(
+        ActivityType: "category_deleted",
+        EntityType: "Category",
+        EntityId: domainEvent.CategoryId,
+        Title: $"\"{domainEvent.Name}\" kategorisi silindi",
+        Details: null,
+        UserId: domainEvent.DeletedById,
+        Timestamp: DateTime.UtcNow
+    );
+}
+
+internal sealed class PostCreatedIntegrationEventConverter : ActivityLogIntegrationEventConverter<PostCreatedEvent>
+{
+    public override string EventType => nameof(PostCreatedEvent);
+
+    protected override ActivityLogCreatedIntegrationEvent Convert(PostCreatedEvent domainEvent) => new(
+        ActivityType: "post_created",
+        EntityType: "Post",
+        EntityId: domainEvent.PostId,
+        Title: $"\"{domainEvent.Title}\" oluşturuldu",
+        Details: $"Kategori ID: {domainEvent.CategoryId}",
+        UserId: domainEvent.CreatedById,
+        Timestamp: DateTime.UtcNow
+    );
+}
+
+internal sealed class PostUpdatedIntegrationEventConverter : ActivityLogIntegrationEventConverter<PostUpdatedEvent>
+{
+    public override string EventType => nameof(PostUpdatedEvent);
+
+    protected override ActivityLogCreatedIntegrationEvent Convert(PostUpdatedEvent domainEvent) => new(
+        ActivityType: "post_updated",
+        EntityType: "Post",
+        EntityId: domainEvent.PostId,
+        Title: $"\"{domainEvent.Title}\" güncellendi",
+        Details: null,
+        UserId: domainEvent.UpdatedById,
+        Timestamp: DateTime.UtcNow
+    );
+}
+
+internal sealed class PostDeletedIntegrationEventConverter : ActivityLogIntegrationEventConverter<PostDeletedEvent>
+{
+    public override string EventType => nameof(PostDeletedEvent);
+
+    protected override ActivityLogCreatedIntegrationEvent Convert(PostDeletedEvent domainEvent) => new(
+        ActivityType: "post_deleted",
+        EntityType: "Post",
+        EntityId: domainEvent.PostId,
+        Title: $"\"{domainEvent.Title}\" silindi",
+        Details: null,
+        UserId: domainEvent.DeletedById,
+        Timestamp: DateTime.UtcNow
+    );
+}
+
+internal sealed class UserCreatedIntegrationEventConverter : ActivityLogIntegrationEventConverter<UserCreatedEvent>
+{
+    public override string EventType => nameof(UserCreatedEvent);
+
+    protected override ActivityLogCreatedIntegrationEvent Convert(UserCreatedEvent domainEvent) => new(
+        ActivityType: "user_created",
+        EntityType: "User",
+        EntityId: domainEvent.UserId,
+        Title: $"Kullanıcı \"{domainEvent.UserName}\" oluşturuldu",
+        Details: $"Email: {domainEvent.Email}",
+        UserId: domainEvent.CreatedById,
+        Timestamp: DateTime.UtcNow
+    );
+}
+
+internal sealed class UserUpdatedIntegrationEventConverter : ActivityLogIntegrationEventConverter<UserUpdatedEvent>
+{
+    public override string EventType => nameof(UserUpdatedEvent);
+
+    protected override ActivityLogCreatedIntegrationEvent Convert(UserUpdatedEvent domainEvent) => new(
+        ActivityType: "user_updated",
+        EntityType: "User",
+        EntityId: domainEvent.UserId,
+        Title: $"Kullanıcı \"{domainEvent.UserName}\" güncellendi",
+        Details: null,
+        UserId: domainEvent.UpdatedById,
+        Timestamp: DateTime.UtcNow
+    );
+}
+
+internal sealed class UserDeletedIntegrationEventConverter : ActivityLogIntegrationEventConverter<UserDeletedEvent>
+{
+    public override string EventType => nameof(UserDeletedEvent);
+
+    protected override ActivityLogCreatedIntegrationEvent Convert(UserDeletedEvent domainEvent) => new(
+        ActivityType: "user_deleted",
+        EntityType: "User",
+        EntityId: domainEvent.UserId,
+        Title: $"Kullanıcı \"{domainEvent.UserName}\" silindi",
+        Details: null,
+        UserId: domainEvent.DeletedById,
+        Timestamp: DateTime.UtcNow
+    );
+}
+
+internal sealed class UserRolesAssignedIntegrationEventConverter : ActivityLogIntegrationEventConverter<UserRolesAssignedEvent>
+{
+    public override string EventType => nameof(UserRolesAssignedEvent);
+
+    protected override ActivityLogCreatedIntegrationEvent Convert(UserRolesAssignedEvent domainEvent) => new(
+        ActivityType: "user_roles_assigned",
+        EntityType: "User",
+        EntityId: domainEvent.UserId,
+        Title: $"Kullanıcı \"{domainEvent.UserName}\" için roller atandı",
+        Details: $"Roller: {string.Join(", ", domainEvent.RoleNames)}",
+        UserId: domainEvent.AssignedById,
+        Timestamp: DateTime.UtcNow
+    );
+}
+
+internal sealed class RoleCreatedIntegrationEventConverter : ActivityLogIntegrationEventConverter<RoleCreatedEvent>
+{
+    public override string EventType => nameof(RoleCreatedEvent);
+
+    protected override ActivityLogCreatedIntegrationEvent Convert(RoleCreatedEvent domainEvent) => new(
+        ActivityType: "role_created",
+        EntityType: "Role",
+        EntityId: domainEvent.RoleId,
+        Title: $"Rol \"{domainEvent.RoleName}\" oluşturuldu",
+        Details: null,
+        UserId: domainEvent.CreatedById,
+        Timestamp: DateTime.UtcNow
+    );
+}
+
+internal sealed class RoleUpdatedIntegrationEventConverter : ActivityLogIntegrationEventConverter<RoleUpdatedEvent>
+{
+    public override string EventType => nameof(RoleUpdatedEvent);
+
+    protected override ActivityLogCreatedIntegrationEvent Convert(RoleUpdatedEvent domainEvent) => new(
+        ActivityType: "role_updated",
+        EntityType: "Role",
+        EntityId: domainEvent.RoleId,
+        Title: $"Rol \"{domainEvent.RoleName}\" güncellendi",
+        Details: null,
+        UserId: domainEvent.UpdatedById,
+        Timestamp: DateTime.UtcNow
+    );
+}
+
+internal sealed class RoleDeletedIntegrationEventConverter : ActivityLogIntegrationEventConverter<RoleDeletedEvent>
+{
+    public override string EventType => nameof(RoleDeletedEvent);
+
+    protected override ActivityLogCreatedIntegrationEvent Convert(RoleDeletedEvent domainEvent) => new(
+        ActivityType: "role_deleted",
+        EntityType: "Role",
+        EntityId: domainEvent.RoleId,
+        Title: $"Rol \"{domainEvent.RoleName}\" silindi",
+        Details: null,
+        UserId: domainEvent.DeletedById,
+        Timestamp: DateTime.UtcNow
+    );
+}
+
+internal sealed class PermissionsAssignedToRoleIntegrationEventConverter : ActivityLogIntegrationEventConverter<PermissionsAssignedToRoleEvent>
+{
+    public override string EventType => nameof(PermissionsAssignedToRoleEvent);
+
+    protected override ActivityLogCreatedIntegrationEvent Convert(PermissionsAssignedToRoleEvent domainEvent) => new(
+        ActivityType: "permissions_assigned_to_role",
+        EntityType: "Role",
+        EntityId: domainEvent.RoleId,
+        Title: $"Rol \"{domainEvent.RoleName}\" için yetkiler atandı",
+        Details: $"{domainEvent.PermissionNames.Count} yetki atandı",
+        UserId: domainEvent.AssignedById,
+        Timestamp: DateTime.UtcNow
+    );
+}

--- a/src/BlogApp.Infrastructure/Services/BackgroundServices/OutboxProcessorService.cs
+++ b/src/BlogApp.Infrastructure/Services/BackgroundServices/OutboxProcessorService.cs
@@ -1,15 +1,14 @@
-using BlogApp.Domain.Events.CategoryEvents;
-using BlogApp.Domain.Events.IntegrationEvents;
-using BlogApp.Domain.Events.PermissionEvents;
-using BlogApp.Domain.Events.PostEvents;
-using BlogApp.Domain.Events.RoleEvents;
-using BlogApp.Domain.Events.UserEvents;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using BlogApp.Domain.Repositories;
+using BlogApp.Infrastructure.Services.BackgroundServices.Outbox.Converters;
 using MassTransit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using System.Text.Json;
 
 namespace BlogApp.Infrastructure.Services.BackgroundServices;
 
@@ -21,16 +20,21 @@ public class OutboxProcessorService : BackgroundService
 {
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<OutboxProcessorService> _logger;
+    private readonly IReadOnlyDictionary<string, IIntegrationEventConverterStrategy> _converterStrategies;
     private readonly TimeSpan _processingInterval = TimeSpan.FromSeconds(5);
     private const int BatchSize = 50;
     private const int MaxRetryCount = 5;
 
     public OutboxProcessorService(
         IServiceProvider serviceProvider,
-        ILogger<OutboxProcessorService> logger)
+        ILogger<OutboxProcessorService> logger,
+        IEnumerable<IIntegrationEventConverterStrategy> converterStrategies)
     {
         _serviceProvider = serviceProvider;
         _logger = logger;
+        _converterStrategies = (converterStrategies ?? throw new ArgumentNullException(nameof(converterStrategies)))
+            .GroupBy(converter => converter.EventType, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -76,29 +80,57 @@ public class OutboxProcessorService : BackgroundService
         {
             try
             {
-                // Event'i deserialize et ve yayınla
-                var integrationEvent = DeserializeEvent(message.EventType, message.Payload);
+                if (!_converterStrategies.TryGetValue(message.EventType, out var converter))
+                {
+                    _logger.LogWarning("Event tipi için converter bulunamadı: {EventType}", message.EventType);
+                    await outboxRepository.MarkAsFailedAsync(
+                        message.Id,
+                        $"Bilinmeyen event tipi: {message.EventType}",
+                        null,
+                        cancellationToken);
+                    await PersistStatusChangesAsync(unitOfWork, message.Id, cancellationToken);
+                    continue;
+                }
+
+                object? integrationEvent;
+
+                try
+                {
+                    integrationEvent = converter.Convert(message.Payload);
+                }
+                catch (Exception conversionException)
+                {
+                    _logger.LogError(conversionException, "{EventType} event'i dönüştürülürken hata oluştu", message.EventType);
+
+                    await outboxRepository.MarkAsFailedAsync(
+                        message.Id,
+                        conversionException.Message,
+                        null,
+                        cancellationToken);
+                    await PersistStatusChangesAsync(unitOfWork, message.Id, cancellationToken);
+                    continue;
+                }
 
                 if (integrationEvent != null)
                 {
                     await publishEndpoint.Publish(integrationEvent, cancellationToken);
 
-                    // İşlenmiş olarak işaretle
                     await outboxRepository.MarkAsProcessedAsync(message.Id, cancellationToken);
-                    await unitOfWork.SaveChangesAsync(cancellationToken);
+                    await PersistStatusChangesAsync(unitOfWork, message.Id, cancellationToken);
 
                     _logger.LogDebug("{MessageId} ID'li {EventType} türündeki outbox mesajı başarıyla yayınlandı",
                         message.Id, message.EventType);
                 }
                 else
                 {
-                    _logger.LogWarning("Event tipi deserialize edilemedi: {EventType}", message.EventType);
+                    _logger.LogWarning("{EventType} event'i dönüştürülemedi", message.EventType);
+
                     await outboxRepository.MarkAsFailedAsync(
                         message.Id,
-                        $"Bilinmeyen event tipi: {message.EventType}",
+                        $"Event dönüştürülemedi: {message.EventType}",
                         null,
                         cancellationToken);
-                    await unitOfWork.SaveChangesAsync(cancellationToken);
+                    await PersistStatusChangesAsync(unitOfWork, message.Id, cancellationToken);
                 }
             }
             catch (Exception ex)
@@ -112,7 +144,7 @@ public class OutboxProcessorService : BackgroundService
                         ex.Message,
                         null,
                         cancellationToken);
-                    await unitOfWork.SaveChangesAsync(cancellationToken);
+                    await PersistStatusChangesAsync(unitOfWork, message.Id, cancellationToken);
                 }
                 else
                 {
@@ -134,267 +166,16 @@ public class OutboxProcessorService : BackgroundService
         }
     }
 
-    private object? DeserializeEvent(string eventType, string payload)
+    private async Task PersistStatusChangesAsync(Domain.Common.IUnitOfWork unitOfWork, Guid messageId, CancellationToken cancellationToken)
     {
         try
         {
-            return eventType switch
-            {
-                // Category Events
-                "CategoryCreatedEvent" => ConvertToIntegrationEvent(
-                    JsonSerializer.Deserialize<CategoryCreatedEvent>(payload)),
-                "CategoryUpdatedEvent" => ConvertToIntegrationEvent(
-                    JsonSerializer.Deserialize<CategoryUpdatedEvent>(payload)),
-                "CategoryDeletedEvent" => ConvertToIntegrationEvent(
-                    JsonSerializer.Deserialize<CategoryDeletedEvent>(payload)),
-
-                // Post Events
-                "PostCreatedEvent" => ConvertToIntegrationEvent(
-                    JsonSerializer.Deserialize<PostCreatedEvent>(payload)),
-                "PostUpdatedEvent" => ConvertToIntegrationEvent(
-                    JsonSerializer.Deserialize<PostUpdatedEvent>(payload)),
-                "PostDeletedEvent" => ConvertToIntegrationEvent(
-                    JsonSerializer.Deserialize<PostDeletedEvent>(payload)),
-
-                // User Events
-                "UserCreatedEvent" => ConvertToIntegrationEvent(
-                    JsonSerializer.Deserialize<UserCreatedEvent>(payload)),
-                "UserUpdatedEvent" => ConvertToIntegrationEvent(
-                    JsonSerializer.Deserialize<UserUpdatedEvent>(payload)),
-                "UserDeletedEvent" => ConvertToIntegrationEvent(
-                    JsonSerializer.Deserialize<UserDeletedEvent>(payload)),
-                "UserRolesAssignedEvent" => ConvertToIntegrationEvent(
-                    JsonSerializer.Deserialize<UserRolesAssignedEvent>(payload)),
-
-                // Role Events
-                "RoleCreatedEvent" => ConvertToIntegrationEvent(
-                    JsonSerializer.Deserialize<RoleCreatedEvent>(payload)),
-                "RoleUpdatedEvent" => ConvertToIntegrationEvent(
-                    JsonSerializer.Deserialize<RoleUpdatedEvent>(payload)),
-                "RoleDeletedEvent" => ConvertToIntegrationEvent(
-                    JsonSerializer.Deserialize<RoleDeletedEvent>(payload)),
-
-                // Permission Events
-                "PermissionsAssignedToRoleEvent" => ConvertToIntegrationEvent(
-                    JsonSerializer.Deserialize<PermissionsAssignedToRoleEvent>(payload)),
-
-                _ => null
-            };
+            await unitOfWork.SaveChangesAsync(cancellationToken);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Event tipi {EventType} deserialize edilirken hata oluştu", eventType);
-            return null;
+            _logger.LogError(ex, "Outbox mesajı {MessageId} durum güncellemeleri kaydedilirken hata oluştu", messageId);
+            throw;
         }
-    }
-
-    private static ActivityLogCreatedIntegrationEvent? ConvertToIntegrationEvent(CategoryCreatedEvent? domainEvent)
-    {
-        if (domainEvent == null) return null;
-
-        return new ActivityLogCreatedIntegrationEvent(
-            ActivityType: "category_created",
-            EntityType: "Category",
-            EntityId: domainEvent.CategoryId,
-            Title: $"\"{domainEvent.Name}\" kategorisi oluşturuldu",
-            Details: null,
-            UserId: domainEvent.CreatedById,
-            Timestamp: DateTime.UtcNow
-        );
-    }
-
-    private static ActivityLogCreatedIntegrationEvent? ConvertToIntegrationEvent(CategoryUpdatedEvent? domainEvent)
-    {
-        if (domainEvent == null) return null;
-
-        return new ActivityLogCreatedIntegrationEvent(
-            ActivityType: "category_updated",
-            EntityType: "Category",
-            EntityId: domainEvent.CategoryId,
-            Title: $"\"{domainEvent.Name}\" kategorisi güncellendi",
-            Details: null,
-            UserId: domainEvent.UpdatedById,
-            Timestamp: DateTime.UtcNow
-        );
-    }
-
-    private static ActivityLogCreatedIntegrationEvent? ConvertToIntegrationEvent(CategoryDeletedEvent? domainEvent)
-    {
-        if (domainEvent == null) return null;
-
-        return new ActivityLogCreatedIntegrationEvent(
-            ActivityType: "category_deleted",
-            EntityType: "Category",
-            EntityId: domainEvent.CategoryId,
-            Title: $"\"{domainEvent.Name}\" kategorisi silindi",
-            Details: null,
-            UserId: domainEvent.DeletedById,
-            Timestamp: DateTime.UtcNow
-        );
-    }
-
-    private static ActivityLogCreatedIntegrationEvent? ConvertToIntegrationEvent(PostCreatedEvent? domainEvent)
-    {
-        if (domainEvent == null) return null;
-
-        return new ActivityLogCreatedIntegrationEvent(
-            ActivityType: "post_created",
-            EntityType: "Post",
-            EntityId: domainEvent.PostId,
-            Title: $"\"{domainEvent.Title}\" oluşturuldu",
-            Details: $"Kategori ID: {domainEvent.CategoryId}",
-            UserId: domainEvent.CreatedById,
-            Timestamp: DateTime.UtcNow
-        );
-    }
-
-    private static ActivityLogCreatedIntegrationEvent? ConvertToIntegrationEvent(PostUpdatedEvent? domainEvent)
-    {
-        if (domainEvent == null) return null;
-
-        return new ActivityLogCreatedIntegrationEvent(
-            ActivityType: "post_updated",
-            EntityType: "Post",
-            EntityId: domainEvent.PostId,
-            Title: $"\"{domainEvent.Title}\" güncellendi",
-            Details: null,
-            UserId: domainEvent.UpdatedById,
-            Timestamp: DateTime.UtcNow
-        );
-    }
-
-    private static ActivityLogCreatedIntegrationEvent? ConvertToIntegrationEvent(PostDeletedEvent? domainEvent)
-    {
-        if (domainEvent == null) return null;
-
-        return new ActivityLogCreatedIntegrationEvent(
-            ActivityType: "post_deleted",
-            EntityType: "Post",
-            EntityId: domainEvent.PostId,
-            Title: $"\"{domainEvent.Title}\" silindi",
-            Details: null,
-            UserId: domainEvent.DeletedById,
-            Timestamp: DateTime.UtcNow
-        );
-    }
-
-    private static ActivityLogCreatedIntegrationEvent? ConvertToIntegrationEvent(UserCreatedEvent? domainEvent)
-    {
-        if (domainEvent == null) return null;
-
-        return new ActivityLogCreatedIntegrationEvent(
-            ActivityType: "user_created",
-            EntityType: "User",
-            EntityId: domainEvent.UserId,
-            Title: $"Kullanıcı \"{domainEvent.UserName}\" oluşturuldu",
-            Details: $"Email: {domainEvent.Email}",
-            UserId: domainEvent.CreatedById,
-            Timestamp: DateTime.UtcNow
-        );
-    }
-
-    private static ActivityLogCreatedIntegrationEvent? ConvertToIntegrationEvent(UserUpdatedEvent? domainEvent)
-    {
-        if (domainEvent == null) return null;
-
-        return new ActivityLogCreatedIntegrationEvent(
-            ActivityType: "user_updated",
-            EntityType: "User",
-            EntityId: domainEvent.UserId,
-            Title: $"Kullanıcı \"{domainEvent.UserName}\" güncellendi",
-            Details: null,
-            UserId: domainEvent.UpdatedById,
-            Timestamp: DateTime.UtcNow
-        );
-    }
-
-    private static ActivityLogCreatedIntegrationEvent? ConvertToIntegrationEvent(UserDeletedEvent? domainEvent)
-    {
-        if (domainEvent == null) return null;
-
-        return new ActivityLogCreatedIntegrationEvent(
-            ActivityType: "user_deleted",
-            EntityType: "User",
-            EntityId: domainEvent.UserId,
-            Title: $"Kullanıcı \"{domainEvent.UserName}\" silindi",
-            Details: null,
-            UserId: domainEvent.DeletedById,
-            Timestamp: DateTime.UtcNow
-        );
-    }
-
-    private static ActivityLogCreatedIntegrationEvent? ConvertToIntegrationEvent(UserRolesAssignedEvent? domainEvent)
-    {
-        if (domainEvent == null) return null;
-
-        return new ActivityLogCreatedIntegrationEvent(
-            ActivityType: "user_roles_assigned",
-            EntityType: "User",
-            EntityId: domainEvent.UserId,
-            Title: $"Kullanıcı \"{domainEvent.UserName}\" için roller atandı",
-            Details: $"Roller: {string.Join(", ", domainEvent.RoleNames)}",
-            UserId: domainEvent.AssignedById,
-            Timestamp: DateTime.UtcNow
-        );
-    }
-
-    private static ActivityLogCreatedIntegrationEvent? ConvertToIntegrationEvent(RoleCreatedEvent? domainEvent)
-    {
-        if (domainEvent == null) return null;
-
-        return new ActivityLogCreatedIntegrationEvent(
-            ActivityType: "role_created",
-            EntityType: "Role",
-            EntityId: domainEvent.RoleId,
-            Title: $"Rol \"{domainEvent.RoleName}\" oluşturuldu",
-            Details: null,
-            UserId: domainEvent.CreatedById,
-            Timestamp: DateTime.UtcNow
-        );
-    }
-
-    private static ActivityLogCreatedIntegrationEvent? ConvertToIntegrationEvent(RoleUpdatedEvent? domainEvent)
-    {
-        if (domainEvent == null) return null;
-
-        return new ActivityLogCreatedIntegrationEvent(
-            ActivityType: "role_updated",
-            EntityType: "Role",
-            EntityId: domainEvent.RoleId,
-            Title: $"Rol \"{domainEvent.RoleName}\" güncellendi",
-            Details: null,
-            UserId: domainEvent.UpdatedById,
-            Timestamp: DateTime.UtcNow
-        );
-    }
-
-    private static ActivityLogCreatedIntegrationEvent? ConvertToIntegrationEvent(RoleDeletedEvent? domainEvent)
-    {
-        if (domainEvent == null) return null;
-
-        return new ActivityLogCreatedIntegrationEvent(
-            ActivityType: "role_deleted",
-            EntityType: "Role",
-            EntityId: domainEvent.RoleId,
-            Title: $"Rol \"{domainEvent.RoleName}\" silindi",
-            Details: null,
-            UserId: domainEvent.DeletedById,
-            Timestamp: DateTime.UtcNow
-        );
-    }
-
-    private static ActivityLogCreatedIntegrationEvent? ConvertToIntegrationEvent(PermissionsAssignedToRoleEvent? domainEvent)
-    {
-        if (domainEvent == null) return null;
-
-        return new ActivityLogCreatedIntegrationEvent(
-            ActivityType: "permissions_assigned_to_role",
-            EntityType: "Role",
-            EntityId: domainEvent.RoleId,
-            Title: $"Rol \"{domainEvent.RoleName}\" için yetkiler atandı",
-            Details: $"{domainEvent.PermissionNames.Count} yetki atandı",
-            UserId: domainEvent.AssignedById,
-            Timestamp: DateTime.UtcNow
-        );
     }
 }


### PR DESCRIPTION
## Summary
- persist each outbox message status update immediately to avoid batch-wide duplication when persistence fails
- expose the integration event converter strategy interface publicly so DI can inject it into the processor

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68fddf5124e88320a72b64391b094975