### PR TITLE
Improve execution context handling for background services

### DIFF
--- a/src/BlogApp.Application/Abstractions/IExecutionContextAccessor.cs
+++ b/src/BlogApp.Application/Abstractions/IExecutionContextAccessor.cs
@@ -1,0 +1,22 @@
+namespace BlogApp.Application.Abstractions;
+
+/// <summary>
+/// Çalışma zamanında kullanılan aktör bilgisini sağlar ve gerektiğinde geçici olarak üzerine yazmaya
+/// imkan tanır. HTTP istekleri dışındaki (ör. arka plan işler) senaryolarda audit alanlarının doğru
+/// doldurulabilmesi için kullanılır.
+/// </summary>
+public interface IExecutionContextAccessor
+{
+    /// <summary>
+    /// Geçerli yürütme bağlamındaki kullanıcı/aktör kimliğini döndürür.
+    /// </summary>
+    /// <returns>Bağlam tanımlıysa kullanıcı ID'si, aksi halde null.</returns>
+    Guid? GetCurrentUserId();
+
+    /// <summary>
+    /// Belirtilen kullanıcı kimliğiyle geçici bir yürütme bağlamı başlatır.
+    /// </summary>
+    /// <param name="userId">Bağlam boyunca geçerli olacak kullanıcı kimliği.</param>
+    /// <returns>Bağlam sona erdiğinde önceki değeri geri yükleyen disposable kapsam.</returns>
+    IDisposable BeginScope(Guid userId);
+}

--- a/src/BlogApp.Infrastructure/InfrastructureServicesRegistration.cs
+++ b/src/BlogApp.Infrastructure/InfrastructureServicesRegistration.cs
@@ -151,6 +151,7 @@ namespace BlogApp.Infrastructure
             services.AddSingleton<ICacheService, RedisCacheService>();
             services.AddTransient<ITokenService, JwtTokenService>();
             services.AddTransient<IMailService, MailService>();
+            services.AddScoped<IExecutionContextAccessor, ExecutionContextAccessor>();
             services.AddScoped<IAuthService, AuthService>();
             services.AddScoped<ICurrentUserService, CurrentUserService>();
             services.AddScoped<IImageStorageService, ImageStorageService>();

--- a/src/BlogApp.Infrastructure/Services/BackgroundServices/SessionCleanupService.cs
+++ b/src/BlogApp.Infrastructure/Services/BackgroundServices/SessionCleanupService.cs
@@ -1,3 +1,5 @@
+using BlogApp.Application.Abstractions;
+using BlogApp.Domain.Constants;
 using BlogApp.Domain.Repositories;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -52,6 +54,9 @@ public class SessionCleanupService : BackgroundService
         {
             using var scope = _serviceProvider.CreateScope();
             var repository = scope.ServiceProvider.GetRequiredService<IRefreshSessionRepository>();
+            var executionContextAccessor = scope.ServiceProvider.GetRequiredService<IExecutionContextAccessor>();
+
+            using var auditScope = executionContextAccessor.BeginScope(SystemUsers.SystemUserId);
 
             var deletedCount = await repository.DeleteExpiredSessionsAsync(cancellationToken);
 

--- a/src/BlogApp.Infrastructure/Services/CurrentUserService.cs
+++ b/src/BlogApp.Infrastructure/Services/CurrentUserService.cs
@@ -1,18 +1,11 @@
 using BlogApp.Application.Abstractions;
-using Microsoft.AspNetCore.Http;
-using System.Security.Claims;
 
 namespace BlogApp.Infrastructure.Services;
 
-public sealed class CurrentUserService(IHttpContextAccessor httpContextAccessor) : ICurrentUserService
+public sealed class CurrentUserService(IExecutionContextAccessor executionContextAccessor) : ICurrentUserService
 {
     public Guid? GetCurrentUserId()
     {
-        var userIdClaim = httpContextAccessor.HttpContext?.User?.FindFirst(ClaimTypes.NameIdentifier);
-        if (userIdClaim != null && Guid.TryParse(userIdClaim.Value, out var userId))
-        {
-            return userId;
-        }
-        return null;
+        return executionContextAccessor.GetCurrentUserId();
     }
 }

--- a/src/BlogApp.Infrastructure/Services/ExecutionContextAccessor.cs
+++ b/src/BlogApp.Infrastructure/Services/ExecutionContextAccessor.cs
@@ -1,0 +1,56 @@
+using System.Security.Claims;
+using System.Threading;
+using BlogApp.Application.Abstractions;
+using Microsoft.AspNetCore.Http;
+
+namespace BlogApp.Infrastructure.Services;
+
+/// <summary>
+/// IHttpContextAccessor tabanlı varsayılan yürütme bağlamı sağlayıcısı. Arka plan işler gibi
+/// HttpContext'in bulunmadığı senaryolar için AsyncLocal üzerinden geçici kullanıcı kimliği atamaya
+/// izin verir.
+/// </summary>
+public sealed class ExecutionContextAccessor(IHttpContextAccessor httpContextAccessor) : IExecutionContextAccessor
+{
+    private static readonly AsyncLocal<Guid?> CurrentUserOverride = new();
+
+    public Guid? GetCurrentUserId()
+    {
+        var overrideValue = CurrentUserOverride.Value;
+        if (overrideValue.HasValue)
+        {
+            return overrideValue;
+        }
+
+        var userIdClaim = httpContextAccessor.HttpContext?.User?.FindFirst(ClaimTypes.NameIdentifier);
+        if (userIdClaim is not null && Guid.TryParse(userIdClaim.Value, out var userId))
+        {
+            return userId;
+        }
+
+        return null;
+    }
+
+    public IDisposable BeginScope(Guid userId)
+    {
+        var previous = CurrentUserOverride.Value;
+        CurrentUserOverride.Value = userId;
+        return new RevertScope(() => CurrentUserOverride.Value = previous);
+    }
+
+    private sealed class RevertScope(Action revertAction) : IDisposable
+    {
+        private bool _disposed;
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            revertAction();
+            _disposed = true;
+        }
+    }
+}

--- a/src/BlogApp.Persistence/Repositories/UnitOfWork.cs
+++ b/src/BlogApp.Persistence/Repositories/UnitOfWork.cs
@@ -52,15 +52,11 @@ public sealed class UnitOfWork : IUnitOfWork
             // - Outbox mesajları (event'ler)
             var result = await _context.SaveChangesAsync(cancellationToken);
 
-            // Başarılı kayıttan sonra domain event'leri temizle
-            // Event'ler artık Outbox tablosunda güvenle saklanıyor
-            ClearDomainEvents();
-
             return result;
         }
         finally
         {
-            // ✅ DÜZELTİLDİ: SaveChanges başarısız olsa bile domain event'lerin her zaman temizlenmesini sağla
+            // SaveChanges başarısız olsa bile domain event'lerin her zaman temizlenmesini sağla
             // Bu, bellek sızıntılarını ve eski event'lerin yeniden işlenmesini önler
             ClearDomainEvents();
         }


### PR DESCRIPTION
## Summary
- add an execution context accessor so audit metadata has an explicit actor outside HTTP requests
- update background services and DbContext auditing to rely on the shared execution context rather than HttpContext
- simplify unit of work domain event cleanup so events are cleared exactly once

## Testing
- dotnet build *(fails: `dotnet` CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_6900cea07c988320baa2bac9aaeb3a81