### PR TITLE
Fix BlogAppDbContext to use execution context accessor

### DIFF
--- a/src/BlogApp.Persistence/Contexts/BlogAppDbContext.cs
+++ b/src/BlogApp.Persistence/Contexts/BlogAppDbContext.cs
@@ -1,5 +1,5 @@
+using BlogApp.Application.Abstractions;
 using BlogApp.Domain.Entities;
-using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
@@ -7,7 +7,10 @@ namespace BlogApp.Persistence.Contexts
 {
     public class BlogAppDbContext : AuditableDbContext
     {
-        public BlogAppDbContext(DbContextOptions<BlogAppDbContext> options, IHttpContextAccessor httpContextAccessor) : base(options, httpContextAccessor)
+        public BlogAppDbContext(
+            DbContextOptions<BlogAppDbContext> options,
+            IExecutionContextAccessor executionContextAccessor)
+            : base(options, executionContextAccessor)
         {
         }
 

--- a/src/BlogApp.Persistence/Contexts/BlogAppDbContextFactory.cs
+++ b/src/BlogApp.Persistence/Contexts/BlogAppDbContextFactory.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Http;
+using BlogApp.Application.Abstractions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
 
@@ -19,9 +19,25 @@ public class BlogAppDbContextFactory : IDesignTimeDbContextFactory<BlogAppDbCont
             b => b.MigrationsHistoryTable("__EFMigrationsHistory", "public")
         );
 
-        // Create a mock HttpContextAccessor for design-time (null is acceptable for migrations)
-        IHttpContextAccessor httpContextAccessor = null!;
+        // Use a lightweight execution context accessor for design-time operations
+        IExecutionContextAccessor executionContextAccessor = new DesignTimeExecutionContextAccessor();
 
-        return new BlogAppDbContext(optionsBuilder.Options, httpContextAccessor);
+        return new BlogAppDbContext(optionsBuilder.Options, executionContextAccessor);
+    }
+
+    private sealed class DesignTimeExecutionContextAccessor : IExecutionContextAccessor
+    {
+        public Guid? GetCurrentUserId() => null;
+
+        public IDisposable BeginScope(Guid userId) => NullScope.Instance;
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+
+            public void Dispose()
+            {
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- inject the execution context accessor into `BlogAppDbContext` so audit dependencies resolve correctly
- update the design-time factory to provide a lightweight execution context accessor implementation for migrations

## Testing
- dotnet build BlogApp.sln *(fails: `bash: command not found: dotnet`)*

------
https://chatgpt.com/codex/tasks/task_e_6900e91af4a08320b9e8d1f9d188bcea