### PR TITLE
Fix scoped dependency resolution for BlogAppDbContext

### DIFF
--- a/src/BlogApp.Persistence/PersistenceServicesRegistration.cs
+++ b/src/BlogApp.Persistence/PersistenceServicesRegistration.cs
@@ -17,11 +17,9 @@ public static class PersistenceServicesRegistration
         #region DbContext Yapılandırması
         var postgreSqlConnectionString = configuration.GetConnectionString("BlogAppPostgreConnectionString");
 
-        services.AddDbContextPool<BlogAppDbContext>((sp, options) =>
+        services.AddDbContext<BlogAppDbContext>((sp, options) =>
         {
             options.UseNpgsql(postgreSqlConnectionString);
-            // ✅ DÜZELTİLDİ: EnableServiceProviderCaching() kaldırıldı - AddDbContextPool ile çakışır
-            // DbContextPool zaten dahili olarak service provider caching'i yönetir
             options.ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning));
         });
 


### PR DESCRIPTION
## Summary
- replace `AddDbContextPool` with `AddDbContext` for `BlogAppDbContext` so scoped dependencies like `IExecutionContextAccessor` can be resolved correctly

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_6900eee7542883208ab47dc5aa4960c6